### PR TITLE
Destroy job definitions after their app destruction

### DIFF
--- a/app/models/barbeque/app.rb
+++ b/app/models/barbeque/app.rb
@@ -4,5 +4,5 @@ class Barbeque::App < Barbeque::ApplicationRecord
 
   attr_readonly :name
 
-  has_many :job_definitions
+  has_many :job_definitions, dependent: :destroy
 end

--- a/app/models/barbeque/job_execution.rb
+++ b/app/models/barbeque/job_execution.rb
@@ -3,7 +3,7 @@ class Barbeque::JobExecution < Barbeque::ApplicationRecord
   belongs_to :job_queue
   has_one :slack_notification, through: :job_definition
   has_one :app, through: :job_definition
-  has_many :job_retries
+  has_many :job_retries, dependent: :destroy
 
   enum status: {
     pending: 0,


### PR DESCRIPTION
## Problem
If you delete an app from web console and its job definition exists, it raises an error on job definitions page.

## Changes
I added `dependent: destroy` to job_definitions association. In addition, added it to job_retries too.

Please review @cookpad/dev-infra 