### PR TITLE
Allow switching log output by BARBEQUE_LOG_TO_STDOUT

### DIFF
--- a/lib/barbeque/worker.rb
+++ b/lib/barbeque/worker.rb
@@ -8,15 +8,23 @@ module Barbeque
 
     DEFAULT_QUEUE = 'default'
 
-    def self.run
+    def self.run(
+      worker_type: 'process',
+      workers:     4,
+      daemonize:   false,
+      log:         $stdout,
+      log_level:   :info,
+      pid_path:    '/tmp/barbeque_worker.pid',
+      supervisor:  true
+    )
       options = {
-        worker_type: 'process',
-        workers:     (ENV['BARBEQUE_WORKER_NUM'] || 4).to_i,
-        daemonize:   ENV['DAEMONIZE_BARBEQUE'] == '1',
-        log:         Rails.env.production? ? Rails.root.join("log/barbeque_worker.log").to_s : $stdout,
-        log_level:   Rails.env.production? ? :info : :debug,
-        pid_path:    Rails.root.join('tmp/pids/barbeque_worker.pid').to_s,
-        supervisor:  Rails.env.production?,
+        worker_type: worker_type,
+        workers:     workers,
+        daemonize:   daemonize,
+        log:         log,
+        log_level:   log_level,
+        pid_path:    pid_path,
+        supervisor:  supervisor,
       }
 
       worker = ServerEngine.create(nil, Barbeque::Worker, options)

--- a/lib/tasks/barbeque_tasks.rake
+++ b/lib/tasks/barbeque_tasks.rake
@@ -7,7 +7,7 @@ namespace :barbeque do
     Barbeque::Worker.run(
       workers:    (ENV['BARBEQUE_WORKER_NUM'] || 4).to_i,
       daemonize:  ENV['DAEMONIZE_BARBEQUE'] == '1',
-      log:        Rails.env.production? ? Rails.root.join('log/barbeque_worker.log').to_s : $stdout,
+      log:        ENV['BARBEQUE_LOG_TO_STDOUT'] == '1' ? $stdout : Rails.root.join('log/barbeque_worker.log').to_s,
       log_level:  Rails.env.production? ? :info : :debug,
       pid_path:   Rails.root.join('tmp/pids/barbeque_worker.pid').to_s,
       supervisor: Rails.env.production?,

--- a/lib/tasks/barbeque_tasks.rake
+++ b/lib/tasks/barbeque_tasks.rake
@@ -2,8 +2,15 @@ namespace :barbeque do
   desc 'Start worker to execute jobs'
   task worker: :environment do
     ENV['BARBEQUE_QUEUE'] ||= 'default'
-
     require 'barbeque/worker'
-    Barbeque::Worker.run
+
+    Barbeque::Worker.run(
+      workers:    (ENV['BARBEQUE_WORKER_NUM'] || 4).to_i,
+      daemonize:  ENV['DAEMONIZE_BARBEQUE'] == '1',
+      log:        Rails.env.production? ? Rails.root.join('log/barbeque_worker.log').to_s : $stdout,
+      log_level:  Rails.env.production? ? :info : :debug,
+      pid_path:   Rails.root.join('tmp/pids/barbeque_worker.pid').to_s,
+      supervisor: Rails.env.production?,
+    )
   end
 end


### PR DESCRIPTION
- Let `Barbeque::Worker` to be independent to Rails
- Switch log output by RAILS_LOG_TO_STDOUT in rake task