### PR TITLE
Add exception handler

### DIFF
--- a/lib/barbeque/configuration.rb
+++ b/lib/barbeque/configuration.rb
@@ -5,7 +5,7 @@ require 'hashie'
 module Barbeque
   module Configuration
     DEFAULT_CONFIG = {
-      'exception_handler' => 'rails_logger',
+      'exception_handler' => 'RailsLogger',
       'runner'            => 'Docker',
     }
 

--- a/lib/barbeque/configuration.rb
+++ b/lib/barbeque/configuration.rb
@@ -4,6 +4,11 @@ require 'hashie'
 
 module Barbeque
   module Configuration
+    DEFAULT_CONFIG = {
+      'exception_handler' => 'rails_logger',
+      'runner'            => 'Docker',
+    }
+
     def config
       @config ||= build_config
     end
@@ -11,7 +16,7 @@ module Barbeque
     def build_config
       filename = Rails.root.join('config', 'barbeque.yml').to_s
       hash = YAML.load(ERB.new(File.read(filename)).result)
-      Hashie::Mash.new(hash[Rails.env])
+      Hashie::Mash.new(DEFAULT_CONFIG.merge(hash[Rails.env]))
     end
   end
 

--- a/lib/barbeque/exception_handler.rb
+++ b/lib/barbeque/exception_handler.rb
@@ -2,23 +2,20 @@ require 'barbeque/configuration'
 
 module Barbeque
   module ExceptionHandler
-    class << self
-      def handle_exception(e)
-        case Barbeque.config.exception_handler
-        when 'rails_logger'
-          rails_logger(e)
-        when 'raven'
-          Raven.capture_exception(e)
-        else
-          Rails.logger.fatal("Unexpected exception handler: #{Barbeque.config.exception_handler}")
-          rails_logger(e)
-        end
-      end
+    def self.handle_exception(e)
+      handler = const_get(Barbeque.config.exception_handler, false)
+      handler.handle_exception(e)
+    end
 
-      private
-
-      def rails_logger(e)
+    module RailsLogger
+      def self.handle_exception(e)
         Rails.logger.error("#{e.inspect}\n#{e.backtrace.join("\n")}")
+      end
+    end
+
+    module Raven
+      def self.handle_exception(e)
+        ::Raven.capture_exception(e)
       end
     end
   end

--- a/lib/barbeque/exception_handler.rb
+++ b/lib/barbeque/exception_handler.rb
@@ -2,9 +2,16 @@ require 'barbeque/configuration'
 
 module Barbeque
   module ExceptionHandler
-    def self.handle_exception(e)
-      handler = const_get(Barbeque.config.exception_handler, false)
-      handler.handle_exception(e)
+    class << self
+      def handle_exception(e)
+        handler.handle_exception(e)
+      end
+
+      private
+
+      def handler
+        @handler ||= const_get(Barbeque.config.exception_handler, false)
+      end
     end
 
     module RailsLogger

--- a/lib/barbeque/exception_handler.rb
+++ b/lib/barbeque/exception_handler.rb
@@ -1,0 +1,25 @@
+require 'barbeque/configuration'
+
+module Barbeque
+  module ExceptionHandler
+    class << self
+      def handle_exception(e)
+        case Barbeque.config.exception_handler
+        when 'rails_logger'
+          rails_logger(e)
+        when 'raven'
+          Raven.capture_exception(e)
+        else
+          Rails.logger.fatal("Unexpected exception handler: #{Barbeque.config.exception_handler}")
+          rails_logger(e)
+        end
+      end
+
+      private
+
+      def rails_logger(e)
+        Rails.logger.error("#{e.inspect}\n#{e.backtrace.join("\n")}")
+      end
+    end
+  end
+end

--- a/lib/barbeque/worker.rb
+++ b/lib/barbeque/worker.rb
@@ -1,3 +1,4 @@
+require 'barbeque/exception_handler'
 require 'barbeque/message_handler'
 require 'barbeque/message_queue'
 require 'serverengine'
@@ -53,8 +54,7 @@ module Barbeque
       handler = MessageHandler.const_get(message.type, false)
       handler.new(message: message, job_queue: message_queue.job_queue).run
     rescue => e
-      # Use Raven.capture_exception
-      Rails.logger.fatal("[ERROR] #{e.inspect}\n#{e.backtrace.join("\n")}")
+      Barbeque::ExceptionHandler.handle_exception(e)
     end
 
     private

--- a/spec/barbeque/configuration_spec.rb
+++ b/spec/barbeque/configuration_spec.rb
@@ -22,6 +22,15 @@ describe Barbeque::Configuration do
       expect(config.runner).to eq('Runner')
     end
 
+    context 'when it has no config' do
+      let(:yaml) { 'rails_env: {}' }
+
+      it 'returns default config' do
+        config = Barbeque.build_config
+        expect(config.runner).to eq('Docker')
+      end
+    end
+
     context 'given erb' do
       let(:yaml) do
         <<-YAML.strip_heredoc

--- a/spec/barbeque/exception_handler_spec.rb
+++ b/spec/barbeque/exception_handler_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'barbeque/exception_handler'
+
+describe Barbeque::ExceptionHandler do
+  describe '.handle_exception' do
+    let(:exception) do
+      StandardError.new('something went wrong').tap do |e|
+        e.set_backtrace(['barbeque.rb:1'])
+      end
+    end
+    let(:handler) { 'RailsLogger' }
+
+    before do
+      allow(Barbeque).to receive_message_chain(:config, :exception_handler).and_return(handler)
+    end
+
+    it 'handles exception with configured handler' do
+      expect(Barbeque::ExceptionHandler::RailsLogger).to receive(:handle_exception).with(exception)
+      Barbeque::ExceptionHandler.handle_exception(exception)
+    end
+  end
+end

--- a/spec/dummy/config/barbeque.yml
+++ b/spec/dummy/config/barbeque.yml
@@ -1,4 +1,5 @@
 default: &default
+  exception_handler: rails_logger
   runner: Docker
 
 development:

--- a/spec/dummy/config/barbeque.yml
+++ b/spec/dummy/config/barbeque.yml
@@ -1,5 +1,5 @@
 default: &default
-  exception_handler: rails_logger
+  exception_handler: RailsLogger
   runner: Docker
 
 development:


### PR DESCRIPTION
## Background
- We want to handle exception with `Raven.capture_exception`.
  - There may be some people who don't want to use `Raven`.
- Exceptions in `Barbeque::Worker` must be rescued and given to this exception handler. 
  - Other exception are properly handled if we configure raven.

## Changes
Add exception handler to handle exception with `Rails.logger` or `Raven`.

Please review :eyeglasses: @cookpad/dev-infra 