### PR TITLE
Autolink stdout and stderr

### DIFF
--- a/app/views/barbeque/job_executions/show.html.haml
+++ b/app/views/barbeque/job_executions/show.html.haml
@@ -78,7 +78,7 @@
           Stdout
 
       .box-body
-        %pre= @stdout
+        %pre= rinku_auto_link(@stdout)
 
   .col-sm-6
     .box.box-primary
@@ -87,6 +87,6 @@
           Stderr
 
       .box-body
-        %pre= @stderr
+        %pre= rinku_auto_link(@stderr)
 
 = link_to 'Back', job_definition_path(@job_execution.job_definition)

--- a/barbeque.gemspec
+++ b/barbeque.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails"
   s.add_dependency "kaminari"
   s.add_dependency "rails", "~> 5.0.0"
+  s.add_dependency "rinku"
   s.add_dependency "sass-rails"
   s.add_dependency "serverengine"
   s.add_dependency "the_garage"

--- a/lib/barbeque/engine.rb
+++ b/lib/barbeque/engine.rb
@@ -1,9 +1,13 @@
+# Gems used by Barbeque::Engine
+require 'rails_rinku'
+
 module Barbeque
   class Engine < ::Rails::Engine
     isolate_namespace Barbeque
 
     config.before_configuration do
-      # Listing gems which are mountable engine or have railtie.
+      # Gems used by Barbeque::Engine, which also have Railtie or Mountable::Engine.
+      # Railtie and Mountable::Engine aren't executed when required normally.
       require 'adminlte2-rails'
       require 'coffee-rails'
       require 'hamlit'


### PR DESCRIPTION
## Background
We want to access urls in job's stdout and stderr easily.

## Changes
I changed urls in a job's stdout and stderr to be linked automatically.

👓 @cookpad/dev-infra 