### PR TITLE
Reuse AWS credentials assumed from Role

### DIFF
--- a/app/services/barbeque/message_enqueuing_service.rb
+++ b/app/services/barbeque/message_enqueuing_service.rb
@@ -3,6 +3,10 @@ require 'aws-sdk'
 class Barbeque::MessageEnqueuingService
   DEFAULT_QUEUE = ENV['BARBEQUE_DEFAULT_QUEUE'] || 'default'
 
+  def self.sqs_client
+    @sqs_client ||= Aws::SQS::Client.new
+  end
+
   # @param [String] application
   # @param [String] job
   # @param [Object] message
@@ -17,7 +21,7 @@ class Barbeque::MessageEnqueuingService
   # @return [String] message_id
   def run
     queue = Barbeque::JobQueue.find_by!(name: @queue)
-    response = client.send_message(
+    response = Barbeque::MessageEnqueuingService.sqs_client.send_message(
       queue_url:    queue.queue_url,
       message_body: build_message.to_json,
     )
@@ -33,9 +37,5 @@ class Barbeque::MessageEnqueuingService
       'Job'         => @job,
       'Message'     => @message,
     }
-  end
-
-  def client
-    @client ||= Aws::SQS::Client.new
   end
 end

--- a/spec/barbeque/execution_log_spec.rb
+++ b/spec/barbeque/execution_log_spec.rb
@@ -15,7 +15,7 @@ describe Barbeque::ExecutionLog do
   let(:stderr)  { 'stderr' }
 
   before do
-    allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+    allow(Barbeque::ExecutionLog).to receive(:s3_client).and_return(s3_client)
   end
 
   describe '.fetch' do

--- a/spec/requests/api/job_retries_spec.rb
+++ b/spec/requests/api/job_retries_spec.rb
@@ -12,7 +12,7 @@ describe 'job_retries' do
     let(:sqs_client) { double('Aws::SQS::Client') }
 
     before do
-      allow(Aws::SQS::Client).to receive(:new).and_return(sqs_client)
+      allow(Barbeque::MessageRetryingService).to receive(:sqs_client).and_return(sqs_client)
     end
 
     it 'enqueues a message to retry a specified message', :autodoc do


### PR DESCRIPTION
## Problem
When we restarted ecs-agent, barbeque raised `Aws::Errors::MissingCredentialsError`. 
https://gist.github.com/k0kubun/ad2f2b15c90d13adec02aa6e41b4de54

Related to https://github.com/aws/aws-sdk-ruby/issues/1301

## Changes
I changed `MessageEnqueuingService`, `MessageRetryingService` and `ExecutionLog` to reuse credentials. Since barbeque stops fetching AWS credentials every time, it'll be easier to restart ecs-agent.

:eyeglasses: @cookpad/dev-infra 