### PR TITLE
Handle Aws::S3::Errors::NoSuchKey on web console

### DIFF
--- a/app/controllers/barbeque/job_executions_controller.rb
+++ b/app/controllers/barbeque/job_executions_controller.rb
@@ -1,10 +1,11 @@
 class Barbeque::JobExecutionsController < Barbeque::ApplicationController
   def show
     @job_execution = Barbeque::JobExecution.find(params[:id])
-    log = @job_execution.execution_log
-    @message = log['message']
-    @stdout  = log['stdout']
-    @stderr  = log['stderr']
+    begin
+      @log = @job_execution.execution_log
+    rescue Aws::S3::Errors::NoSuchKey
+      @log = nil
+    end
   end
 
   def retry

--- a/app/controllers/barbeque/job_executions_controller.rb
+++ b/app/controllers/barbeque/job_executions_controller.rb
@@ -1,11 +1,7 @@
 class Barbeque::JobExecutionsController < Barbeque::ApplicationController
   def show
     @job_execution = Barbeque::JobExecution.find(params[:id])
-    begin
-      @log = @job_execution.execution_log
-    rescue Aws::S3::Errors::NoSuchKey
-      @log = nil
-    end
+    @log = @job_execution.execution_log
   end
 
   def retry

--- a/app/controllers/barbeque/job_retries_controller.rb
+++ b/app/controllers/barbeque/job_retries_controller.rb
@@ -1,10 +1,17 @@
 class Barbeque::JobRetriesController < Barbeque::ApplicationController
   def show
     @job_execution = Barbeque::JobExecution.find(params[:job_execution_id])
-    @message = @job_execution.execution_log['message']
+    begin
+      @execution_log = @job_execution.execution_log
+    rescue Aws::S3::Errors::NoSuchKey
+      @execution_log = nil
+    end
 
     @job_retry = Barbeque::JobRetry.find(params[:id])
-    @stdout = @job_retry.execution_log['stdout']
-    @stderr = @job_retry.execution_log['stderr']
+    begin
+      @retry_log = @job_retry.execution_log
+    rescue Aws::S3::Errors::NoSuchKey
+      @retry_log = nil
+    end
   end
 end

--- a/app/controllers/barbeque/job_retries_controller.rb
+++ b/app/controllers/barbeque/job_retries_controller.rb
@@ -1,17 +1,9 @@
 class Barbeque::JobRetriesController < Barbeque::ApplicationController
   def show
     @job_execution = Barbeque::JobExecution.find(params[:job_execution_id])
-    begin
-      @execution_log = @job_execution.execution_log
-    rescue Aws::S3::Errors::NoSuchKey
-      @execution_log = nil
-    end
+    @execution_log = @job_execution.execution_log
 
     @job_retry = Barbeque::JobRetry.find(params[:id])
-    begin
-      @retry_log = @job_retry.execution_log
-    rescue Aws::S3::Errors::NoSuchKey
-      @retry_log = nil
-    end
+    @retry_log = @job_retry.execution_log
   end
 end

--- a/app/views/barbeque/job_executions/show.html.haml
+++ b/app/views/barbeque/job_executions/show.html.haml
@@ -38,7 +38,10 @@
             %tr
               %th Message
               %td
-                %code= @message
+                - if @log
+                  %code= @log['message']
+                - else
+                  Log was not found.
   .col-sm-5
     .box.box-primary
       .box-header
@@ -78,7 +81,10 @@
           Stdout
 
       .box-body
-        %pre= rinku_auto_link(@stdout)
+        - if @log
+          %pre= rinku_auto_link(@log['stdout'])
+        - else
+          Log was not found.
 
   .col-sm-6
     .box.box-primary
@@ -87,6 +93,9 @@
           Stderr
 
       .box-body
-        %pre= rinku_auto_link(@stderr)
+        - if @log
+          %pre= rinku_auto_link(@log['stderr'])
+        - else
+          Log was not found.
 
 = link_to 'Back', job_definition_path(@job_execution.job_definition)

--- a/app/views/barbeque/job_retries/show.html.haml
+++ b/app/views/barbeque/job_retries/show.html.haml
@@ -35,7 +35,10 @@
             %tr
               %th Message
               %td
-                %code= @message
+                - if @execution_log
+                  %code= @execution_log['message']
+                - else
+                  Execution log was not found.
 
 .row
   .col-sm-6
@@ -45,7 +48,10 @@
           Stdout
 
       .box-body
-        %pre= @stdout
+        - if @retry_log
+          %pre= @retry_log['stdout']
+        - else
+          Retry log was not found.
 
   .col-sm-6
     .box.box-primary
@@ -54,6 +60,9 @@
           Stderr
 
       .box-body
-        %pre= @stderr
+        - if @retry_log
+          %pre= @retry_log['stderr']
+        - else
+          Retry log was not found.
 
 = link_to 'Back', job_execution_path(@job_execution)

--- a/lib/barbeque/execution_log.rb
+++ b/lib/barbeque/execution_log.rb
@@ -30,6 +30,8 @@ module Barbeque
         key:    s3_key_for(execution: execution),
       )
       JSON.load(s3_object.body.read)
+    rescue Aws::S3::Errors::NoSuchKey
+      nil
     end
 
     private

--- a/lib/barbeque/message_handler/job_retry.rb
+++ b/lib/barbeque/message_handler/job_retry.rb
@@ -5,6 +5,8 @@ require 'barbeque/slack_client'
 
 module Barbeque
   module MessageHandler
+    class MessageNotFound < StandardError; end
+
     class JobRetry
       # @param [Barbeque::Message::JobExecution] message
       # @param [Barbeque::JobQueue] job_queue
@@ -70,6 +72,10 @@ module Barbeque
       end
 
       def job_envs
+        if job_execution.execution_log.nil?
+          raise MessageNotFound.new('failed to fetch retried message')
+        end
+
         {
           'BARBEQUE_JOB'         => job_execution.job_definition.job,
           'BARBEQUE_MESSAGE'     => job_execution.execution_log['message'],

--- a/spec/barbeque/message_handler/job_retry_spec.rb
+++ b/spec/barbeque/message_handler/job_retry_spec.rb
@@ -113,5 +113,15 @@ describe Barbeque::MessageHandler::JobRetry do
         end
       end
     end
+
+    context 'when retried message is missing' do
+      before do
+        allow(Barbeque::ExecutionLog).to receive(:load).with(execution: job_execution).and_return(nil)
+      end
+
+      it 'raises MessageNotFound' do
+        expect { handler.run }.to raise_error(Barbeque::MessageHandler::MessageNotFound)
+      end
+    end
   end
 end

--- a/spec/controllers/barbeque/job_executions_controller_spec.rb
+++ b/spec/controllers/barbeque/job_executions_controller_spec.rb
@@ -25,9 +25,7 @@ describe Barbeque::JobExecutionsController do
 
     it 'shows message, stdout, stderr in S3' do
       get :show, params: { id: job_execution.id }
-      expect(assigns(:message)).to eq(message)
-      expect(assigns(:stdout)).to eq(stdout)
-      expect(assigns(:stderr)).to eq(stderr)
+      expect(assigns(:log)).to eq({ 'message' => message, 'stdout' => stdout, 'stderr' => stderr })
     end
   end
 

--- a/spec/controllers/barbeque/job_retries_controller_spec.rb
+++ b/spec/controllers/barbeque/job_retries_controller_spec.rb
@@ -29,9 +29,8 @@ describe Barbeque::JobRetriesController do
 
     it 'shows message, stdout, stderr in S3' do
       get :show, params: { job_execution_id: job_execution.id, id: job_retry.id }
-      expect(assigns(:message)).to eq(message)
-      expect(assigns(:stdout)).to eq(stdout)
-      expect(assigns(:stderr)).to eq(stderr)
+      expect(assigns(:execution_log)).to eq(execution_log)
+      expect(assigns(:retry_log)).to eq(retry_log)
     end
   end
 end


### PR DESCRIPTION
Sometimes we fail to save logs to S3, i.e. https://github.com/cookpad/barbeque/pull/9. It's too unkind to return 500 to people who see web console. So I want to rescue the error and show "Log was not found" message.

:eyeglasses: @cookpad/dev-infra 