### PR TITLE
Add execution id and html_url to status API response

### DIFF
--- a/app/models/barbeque/api/job_execution_resource.rb
+++ b/app/models/barbeque/api/job_execution_resource.rb
@@ -3,5 +3,22 @@ class Barbeque::Api::JobExecutionResource < Barbeque::Api::ApplicationResource
 
   property :status
 
-  delegate :message_id, :status, to: :model
+  property :id
+
+  property :html_url, selectable: true
+
+  delegate :message_id, :status, :id, to: :model
+
+  def initialize(model, url_options)
+    super(model)
+    @url_options = url_options
+  end
+
+  def html_url
+    if model.id
+      Barbeque::Engine.routes.url_helpers.job_execution_url(model, @url_options)
+    else
+      nil
+    end
+  end
 end

--- a/app/models/barbeque/job_execution.rb
+++ b/app/models/barbeque/job_execution.rb
@@ -18,8 +18,4 @@ class Barbeque::JobExecution < Barbeque::ApplicationRecord
   def execution_log
     @execution_log ||= Barbeque::ExecutionLog.load(execution: self)
   end
-
-  def to_resource
-    Barbeque::Api::JobExecutionResource.new(self)
-  end
 end

--- a/doc/api/job_executions.md
+++ b/doc/api/job_executions.md
@@ -5,7 +5,7 @@ Shows a status of a job_execution.
 
 #### Request
 ```
-GET /v1/job_executions/5b1b63e9-487c-4b13-95fa-b1676036e787 HTTP/1.1
+GET /v1/job_executions/a0cb3899-f458-4389-bc45-f3e1380ebe94 HTTP/1.1
 Accept: application/json
 Content-Length: 0
 Content-Type: application/json
@@ -16,18 +16,54 @@ Host: www.example.com
 ```
 HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
-Content-Length: 72
+Content-Length: 81
 Content-Type: application/json; charset=utf-8
-ETag: W/"34c1ce245b791e3e03c59d4a6cd0c305"
+ETag: W/"fd6c1c7a7d062a6d47b978a65ced9d08"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 79ee9e9e-4ff3-4779-b9fa-0cfb721f7b6d
-X-Runtime: 0.013260
+X-Request-Id: afbf03b0-450f-49d5-8741-14906ff4495e
+X-Runtime: 0.011198
 X-XSS-Protection: 1; mode=block
 
 {
-  "message_id": "5b1b63e9-487c-4b13-95fa-b1676036e787",
-  "status": "success"
+  "message_id": "a0cb3899-f458-4389-bc45-f3e1380ebe94",
+  "status": "success",
+  "id": 277
+}
+```
+
+## GET /v1/job_executions/:message_id
+Shows url to job_execution.
+
+### Example
+
+#### Request
+```
+GET /v1/job_executions/f3e3b7a2-3517-47d4-aa58-8e531c2bfa3b?fields=__default__,html_url HTTP/1.1
+Accept: application/json
+Content-Length: 0
+Content-Type: application/json
+Host: www.example.com
+```
+
+#### Response
+```
+HTTP/1.1 200
+Cache-Control: max-age=0, private, must-revalidate
+Content-Length: 136
+Content-Type: application/json; charset=utf-8
+ETag: W/"4c1e26dbc5c441e68ced4559ae1ca13c"
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Request-Id: 9eef7915-4054-4494-8c2d-6f9312c208f6
+X-Runtime: 0.005148
+X-XSS-Protection: 1; mode=block
+
+{
+  "message_id": "f3e3b7a2-3517-47d4-aa58-8e531c2bfa3b",
+  "status": "success",
+  "id": 278,
+  "html_url": "http://www.example.com/job_executions/278"
 }
 ```
 
@@ -53,7 +89,7 @@ Host: www.example.com
 {
   "application": "blog",
   "job": "NotifyAuthor",
-  "queue": "queue-40",
+  "queue": "queue-45",
   "message": {
     "recipe_id": 1
   }
@@ -64,17 +100,18 @@ Host: www.example.com
 ```
 HTTP/1.1 201
 Cache-Control: max-age=0, private, must-revalidate
-Content-Length: 72
+Content-Length: 82
 Content-Type: application/json; charset=utf-8
-ETag: W/"da17a00ccd410c48451c5dd35d5ca571"
+ETag: W/"989676f33ea349525dc206be62f5fa74"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 8f850294-5519-4b97-924e-ce38815b42bc
-X-Runtime: 0.003626
+X-Request-Id: fe0b4e31-3e13-40b8-a7bc-25c99a1bc912
+X-Runtime: 0.005131
 X-XSS-Protection: 1; mode=block
 
 {
-  "message_id": "8e6cff6b-fcbf-4bef-8fb2-cfb4a60b5db8",
-  "status": "pending"
+  "message_id": "ea17fa06-9581-4252-9f42-7474e16ab679",
+  "status": "pending",
+  "id": null
 }
 ```

--- a/doc/api/job_retries.md
+++ b/doc/api/job_retries.md
@@ -8,7 +8,7 @@ Enqueues a message to retry a specified message.
 
 #### Request
 ```
-POST /v1/job_executions/3c64334d-6a33-4e72-83ab-4fa508babc02/retries HTTP/1.1
+POST /v1/job_executions/aad5f81d-99d0-43ce-b294-b24f35569848/retries HTTP/1.1
 Accept: application/json
 Content-Length: 0
 Content-Type: application/json
@@ -21,15 +21,15 @@ HTTP/1.1 201
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 72
 Content-Type: application/json; charset=utf-8
-ETag: W/"14540567ec57d195c9ee7b21126abb44"
+ETag: W/"f841b1a72e241c4a187ba74447f78349"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 31e59909-0211-4cd5-8e9e-188c4b049585
-X-Runtime: 0.008684
+X-Request-Id: 8b1ccd38-1f5e-4b2b-abcd-21a55d1b4864
+X-Runtime: 0.012412
 X-XSS-Protection: 1; mode=block
 
 {
-  "message_id": "ea8b7fe7-b8a9-4b0d-b938-195e83aab713",
+  "message_id": "780e8972-a466-4f9d-9a8a-3a1409b85450",
   "status": "pending"
 }
 ```

--- a/doc/api/revision_locks.md
+++ b/doc/api/revision_locks.md
@@ -8,7 +8,7 @@ Updates a tag of docker_image.
 
 #### Request
 ```
-POST /v1/apps/app-49/revision_lock HTTP/1.1
+POST /v1/apps/app-52/revision_lock HTTP/1.1
 Accept: application/json
 Content-Length: 55
 Content-Type: application/json
@@ -28,8 +28,8 @@ Content-Type: application/json; charset=utf-8
 ETag: W/"a3f0b3d8c32ee1e318357b5276e50a3c"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: f903289a-c963-4e6c-ad00-4a03b3062306
-X-Runtime: 0.015287
+X-Request-Id: 82f9d82a-d887-4ebe-b784-bd3865b057ae
+X-Runtime: 0.011747
 X-XSS-Protection: 1; mode=block
 
 {
@@ -44,7 +44,7 @@ Updates a tag of docker_image.
 
 #### Request
 ```
-DELETE /v1/apps/app-51/revision_lock HTTP/1.1
+DELETE /v1/apps/app-54/revision_lock HTTP/1.1
 Accept: application/json
 Content-Length: 0
 Content-Type: application/json
@@ -57,7 +57,7 @@ HTTP/1.1 204
 Cache-Control: no-cache
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 73ac851c-ec74-4dc5-8ce8-1917cb0c8a8f
-X-Runtime: 0.007907
+X-Request-Id: 68cbf752-1e39-4a2d-b26a-3ea65694f5bb
+X-Runtime: 0.008371
 X-XSS-Protection: 1; mode=block
 ```

--- a/doc/toc.md
+++ b/doc/toc.md
@@ -1,6 +1,7 @@
 ## Table of Contents
 * [api/job_executions.md](api/job_executions.md)
  * [GET /v1/job_executions/:message_id](api/job_executions.md#get-v1job_executionsmessage_id)
+ * [GET /v1/job_executions/:message_id](api/job_executions.md#get-v1job_executionsmessage_id-1)
  * [POST /v2/job_executions](api/job_executions.md#post-v2job_executions)
 * [api/job_retries.md](api/job_retries.md)
  * [POST /v1/job_executions/:job_execution_message_id/retries](api/job_retries.md#post-v1job_executionsjob_execution_message_idretries)

--- a/spec/requests/api/job_executions_spec.rb
+++ b/spec/requests/api/job_executions_spec.rb
@@ -11,10 +11,23 @@ describe 'job_executions' do
 
       it 'shows a status of a job_execution', :autodoc do
         get "/v1/job_executions/#{job_execution.message_id}", env: env
-        expect(result).to match({
+        expect(result).to eq(
           'message_id' => job_execution.message_id,
           'status'     => status,
-        })
+          'id'         => job_execution.id,
+        )
+      end
+
+      context 'when requested with fields=html_url', :autodoc do
+        it 'shows url to job_execution' do
+          get "/v1/job_executions/#{job_execution.message_id}?fields=__default__,html_url", env: env
+          expect(result).to eq(
+            'message_id' => job_execution.message_id,
+            'status'     => status,
+            'id'         => job_execution.id,
+            'html_url'   => "http://www.example.com/job_executions/#{job_execution.id}",
+          )
+        end
       end
     end
 
@@ -23,10 +36,23 @@ describe 'job_executions' do
 
       it 'returns pending as status' do
         get "/v1/job_executions/#{message_id}", env: env
-        expect(result).to match({
+        expect(result).to eq(
           'message_id' => message_id,
           'status'     => 'pending',
-        })
+          'id'         => nil,
+        )
+      end
+
+      context 'when requested with fields=html_url' do
+        it "doesn't shows url" do
+          get "/v1/job_executions/#{message_id}?fields=__default__,html_url", env: env
+          expect(result).to eq(
+            'message_id' => message_id,
+            'status'     => 'pending',
+            'id'         => nil,
+            'html_url'   => nil,
+          )
+        end
       end
     end
   end
@@ -62,6 +88,7 @@ describe 'job_executions' do
       expect(result).to eq({
         'message_id' => message_id,
         'status'     => 'pending',
+        'id'         => nil,
       })
     end
 
@@ -71,6 +98,18 @@ describe 'job_executions' do
       it 'returns 404' do
         post '/v2/job_executions', params: params.to_json, env: env
         expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when requested with fields=html_url' do
+      it "doesn't shows url" do
+        get "/v1/job_executions/#{message_id}?fields=__default__,html_url", env: env
+        expect(result).to eq(
+          'message_id' => message_id,
+          'status'     => 'pending',
+          'id'         => nil,
+          'html_url'   => nil,
+        )
       end
     end
   end


### PR DESCRIPTION
It's useful when we'd like to navigate users to job execution result
page in barbeque console.

@cookpad/dev-infra please review