### PR TITLE
Make operation to deduplicate messages atomic

### DIFF
--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -14,9 +14,11 @@ module Barbeque
       end
 
       def run
-        job_execution = Barbeque::JobExecution.find_or_initialize_by(message_id: @message.id)
-        raise DuplicatedExecution if job_execution.persisted?
-        job_execution.update!(job_definition: job_definition, job_queue_id: @job_queue.id)
+        begin
+          job_execution = Barbeque::JobExecution.create(message_id: @message.id, job_definition: job_definition, job_queue: @job_queue)
+        rescue ActiveRecord::RecordNotUnique
+          raise DuplicatedExecution
+        end
 
         stdout, stderr, status = run_command
         job_execution.update!(status: status.success? ? :success : :failed, finished_at: Time.now)

--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -16,8 +16,8 @@ module Barbeque
       def run
         begin
           job_execution = Barbeque::JobExecution.create(message_id: @message.id, job_definition: job_definition, job_queue: @job_queue)
-        rescue ActiveRecord::RecordNotUnique
-          raise DuplicatedExecution
+        rescue ActiveRecord::RecordNotUnique => e
+          raise DuplicatedExecution.new(e.message)
         end
 
         stdout, stderr, status = run_command

--- a/lib/barbeque/message_handler/job_retry.rb
+++ b/lib/barbeque/message_handler/job_retry.rb
@@ -16,8 +16,11 @@ module Barbeque
       end
 
       def run
-        job_retry = Barbeque::JobRetry.find_or_initialize_by(message_id: @message.id)
-        job_retry.update!(job_execution: job_execution)
+        begin
+          job_retry = Barbeque::JobRetry.create(message_id: @message.id, job_execution: job_execution)
+        rescue ActiveRecord::RecordNotUnique
+          raise DuplicatedExecution
+        end
         job_execution.update!(status: 'retried')
 
         stdout, stderr, result = run_command

--- a/lib/barbeque/message_handler/job_retry.rb
+++ b/lib/barbeque/message_handler/job_retry.rb
@@ -18,8 +18,8 @@ module Barbeque
       def run
         begin
           job_retry = Barbeque::JobRetry.create(message_id: @message.id, job_execution: job_execution)
-        rescue ActiveRecord::RecordNotUnique
-          raise DuplicatedExecution
+        rescue ActiveRecord::RecordNotUnique => e
+          raise DuplicatedExecution.new(e.message)
         end
         job_execution.update!(status: 'retried')
 

--- a/spec/barbeque/message_handler/job_retry_spec.rb
+++ b/spec/barbeque/message_handler/job_retry_spec.rb
@@ -123,5 +123,15 @@ describe Barbeque::MessageHandler::JobRetry do
         expect { handler.run }.to raise_error(Barbeque::MessageHandler::MessageNotFound)
       end
     end
+
+    context 'when job_retry already exists' do
+      before do
+        create(:job_retry, message_id: message.id)
+      end
+
+      it 'raises DuplicatedExecution' do
+        expect { handler.run }.to raise_error(Barbeque::MessageHandler::DuplicatedExecution)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Background
In `Barbeque::MessageHandler::JobExecution`, we execute SELECT and INSERT queries for job_execution without a transaction. We didn't introduce a transaction to avoid performance regression. So it is possible that a single job is executed twice.

But I noticed that we can create a record and detect duplication in a single INSERT query because we have message_id unique index.

## Changes
So I changed `Barbeque::MessageHandler::JobExecution` to use such a query. I also applied it to `Barbeque::MessageHandler::JobExecution`.

I believe this PR resolves message duplication by SQS's at-least-once delivery.