### PR TITLE
Order job_retries in reverse order

### DIFF
--- a/app/controllers/barbeque/job_executions_controller.rb
+++ b/app/controllers/barbeque/job_executions_controller.rb
@@ -2,6 +2,7 @@ class Barbeque::JobExecutionsController < Barbeque::ApplicationController
   def show
     @job_execution = Barbeque::JobExecution.find(params[:id])
     @log = @job_execution.execution_log
+    @job_retries = @job_execution.job_retries.order(id: :desc)
   end
 
   def retry

--- a/app/views/barbeque/job_executions/show.html.haml
+++ b/app/views/barbeque/job_executions/show.html.haml
@@ -49,7 +49,7 @@
           Retries
 
       .box-body
-        - if @job_execution.job_retries.present?
+        - if @job_retries.present?
           %table.table.table-bordered
             %thead
               %tr
@@ -59,7 +59,7 @@
                 %th Elapsed Time
                 %th
             %tbody
-              - @job_execution.job_retries.each do |job_retry|
+              - @job_retries.each do |job_retry|
                 %tr
                   %td= job_retry.id
                   %td= status_label(job_retry.status)


### PR DESCRIPTION
For consistency with job_executions's order in job_definition page.

@cookpad/dev-infra please review