### PR TITLE
Add error handling around SNS API calls

### DIFF
--- a/app/controllers/barbeque/sns_subscriptions_controller.rb
+++ b/app/controllers/barbeque/sns_subscriptions_controller.rb
@@ -30,7 +30,7 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
         @sns_topic_arns = fetch_sns_topic_arns
         render :new
       else
-        @sns_subscription.save
+        @sns_subscription.save!
         update_sqs_policy!
         redirect_to @sns_subscription, notice: 'SNS subscription was successfully created.'
       end

--- a/app/controllers/barbeque/sns_subscriptions_controller.rb
+++ b/app/controllers/barbeque/sns_subscriptions_controller.rb
@@ -42,7 +42,6 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
   def update
     @sns_subscription = Barbeque::SNSSubscription.find(params[:id])
     if @sns_subscription.update(params.require(:sns_subscription).permit(:job_definition_id))
-      update_sqs_policy!
       redirect_to @sns_subscription, notice: 'SNS subscription was successfully updated.'
     else
       render :edit

--- a/app/controllers/barbeque/sns_subscriptions_controller.rb
+++ b/app/controllers/barbeque/sns_subscriptions_controller.rb
@@ -61,8 +61,6 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
 
   def fetch_sns_topic_arns
     sns_client.list_topics.topics.map(&:topic_arn)
-  rescue Aws::Errors::MissingCredentialsError, Aws::SNS::Errors::AuthorizationError
-    []
   end
 
   def update_sqs_policy!

--- a/app/controllers/barbeque/sns_subscriptions_controller.rb
+++ b/app/controllers/barbeque/sns_subscriptions_controller.rb
@@ -18,11 +18,22 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
 
   def create
     @sns_subscription = Barbeque::SNSSubscription.new(params.require(:sns_subscription).permit(:topic_arn, :job_queue_id, :job_definition_id))
-
-    if @sns_subscription.save
-      update_sqs_policy!
-      subscribe_topic!
-      redirect_to @sns_subscription, notice: 'SNS subscription was successfully created.'
+    if @sns_subscription.valid?
+      begin
+        subscribe_topic!
+      rescue Aws::SNS::Errors::AuthorizationError
+        @sns_subscription.errors[:topic_arn] << 'is not authorized'
+        @sns_topic_arns = fetch_sns_topic_arns
+        render :new
+      rescue Aws::SNS::Errors::NotFound
+        @sns_subscription.errors[:topic_arn] << 'is not found'
+        @sns_topic_arns = fetch_sns_topic_arns
+        render :new
+      else
+        @sns_subscription.save
+        update_sqs_policy!
+        redirect_to @sns_subscription, notice: 'SNS subscription was successfully created.'
+      end
     else
       render :new
     end
@@ -50,6 +61,8 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
 
   def fetch_sns_topic_arns
     sns_client.list_topics.topics.map(&:topic_arn)
+  rescue Aws::Errors::MissingCredentialsError, Aws::SNS::Errors::AuthorizationError
+    []
   end
 
   def update_sqs_policy!

--- a/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
+++ b/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
@@ -68,6 +68,17 @@ describe Barbeque::SnsSubscriptionsController do
         expect(assigns(:sns_subscription).errors[:topic_arn]).to eq(['is not found'])
       end
     end
+
+    context 'with AuthorizationError' do
+      it 'does not create a record and shows error message' do
+        expect(sqs_client).not_to receive(:get_queue_attributes)
+        expect(controller).to receive(:subscribe_topic!).and_raise(Aws::SNS::Errors::AuthorizationError.new(self, 'not found'))
+        allow(controller).to receive(:fetch_sns_topic_arns).and_return([])
+        post :create , params: { sns_subscription: attributes }
+        expect(response).to render_template(:new)
+        expect(assigns(:sns_subscription).errors[:topic_arn]).to eq(['is not authorized'])
+      end
+    end
   end
 
   describe '#destroy' do

--- a/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
+++ b/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
@@ -57,6 +57,17 @@ describe Barbeque::SnsSubscriptionsController do
       expect { post :create , params: { sns_subscription: attributes } }.
         to change { Barbeque::SNSSubscription.count }.by(1)
     end
+
+    context 'with NotFound error' do
+      it 'does not create a record and shows error message' do
+        expect(sqs_client).not_to receive(:get_queue_attributes)
+        expect(controller).to receive(:subscribe_topic!).and_raise(Aws::SNS::Errors::NotFound.new(self, 'not found'))
+        allow(controller).to receive(:fetch_sns_topic_arns).and_return([])
+        post :create , params: { sns_subscription: attributes }
+        expect(response).to render_template(:new)
+        expect(assigns(:sns_subscription).errors[:topic_arn]).to eq(['is not found'])
+      end
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
I add error handling around SNS API calls.
In our environment we want to restrict available topics to subscribe by IAM roles. So if a user is setting a restricted topic, Barbeque returns 500 error for now.
This patch avoids 500 error and shows error messages when accessing unauthorized topic or not found.

@cookpad/dev-infra @k0kubun How do you think?