### PR TITLE
Set error status when unhandled exception is raised from runner

### DIFF
--- a/app/controllers/barbeque/job_executions_controller.rb
+++ b/app/controllers/barbeque/job_executions_controller.rb
@@ -7,7 +7,7 @@ class Barbeque::JobExecutionsController < Barbeque::ApplicationController
 
   def retry
     @job_execution = Barbeque::JobExecution.find(params[:job_execution_id])
-    raise ActionController::BadRequest unless @job_execution.failed?
+    raise ActionController::BadRequest unless @job_execution.retryable?
 
     result = Barbeque::MessageRetryingService.new(message_id: @job_execution.message_id).run
     @job_execution.retried!

--- a/app/helpers/barbeque/job_executions_helper.rb
+++ b/app/helpers/barbeque/job_executions_helper.rb
@@ -10,6 +10,8 @@ module Barbeque::JobExecutionsHelper
         'warning'
       when 'pending'
         'info'
+      when 'error'
+        'danger'
       else
         'default'
       end

--- a/app/models/barbeque/job_execution.rb
+++ b/app/models/barbeque/job_execution.rb
@@ -10,6 +10,7 @@ class Barbeque::JobExecution < Barbeque::ApplicationRecord
     success: 1,
     failed:  2,
     retried: 3,
+    error: 4,
   }
 
   paginates_per 15
@@ -17,5 +18,9 @@ class Barbeque::JobExecution < Barbeque::ApplicationRecord
   # @return [Hash] - A hash created by `JobExecutor::Job#log_result`
   def execution_log
     @execution_log ||= Barbeque::ExecutionLog.load(execution: self)
+  end
+
+  def retryable?
+    failed? || error?
   end
 end

--- a/app/models/barbeque/job_retry.rb
+++ b/app/models/barbeque/job_retry.rb
@@ -9,6 +9,7 @@ class Barbeque::JobRetry < Barbeque::ApplicationRecord
     success: 1,
     failed:  2,
     retried: 3,
+    error: 4,
   }
 
   # @return [Hash] - A hash created by `JobExecutor::Retry#log_result`

--- a/app/views/barbeque/job_definitions/show.html.haml
+++ b/app/views/barbeque/job_definitions/show.html.haml
@@ -65,7 +65,7 @@
                       = link_to job_execution_path(job_execution), class: 'btn btn-default btn-sm btn-flat' do
                         %i.fa.fa-chevron-right
                         Details
-                      - if job_execution.failed?
+                      - if job_execution.retryable?
                         = link_to job_execution_retry_path(job_execution), method: :post, class: 'btn btn-default btn-sm btn-flat',
                           data: { disable_with: 'retrying...', confirm: "Are you sure to retry #{@job_definition.job} ##{job_execution.id}?" } do
                           %i.fa.fa-refresh

--- a/app/views/barbeque/job_executions/show.html.haml
+++ b/app/views/barbeque/job_executions/show.html.haml
@@ -8,7 +8,7 @@
               \##{@job_execution.id} of
               = link_to @job_execution.job_definition do
                 #{@job_execution.job_definition.job}
-          - if @job_execution.failed?
+          - if @job_execution.retryable?
             .col-md-2
               = link_to job_execution_retry_path(@job_execution), method: :post, class: 'btn btn-default btn-block pull-right',
                 data: { disable_with: 'retrying...', confirm: "Are you sure to retry #{@job_execution.job_definition.job} ##{@job_execution.id}?" } do

--- a/spec/barbeque/message_handler/job_execution_spec.rb
+++ b/spec/barbeque/message_handler/job_execution_spec.rb
@@ -116,5 +116,19 @@ describe Barbeque::MessageHandler::JobExecution do
         expect { handler.run }.to raise_error(Barbeque::MessageHandler::DuplicatedExecution)
       end
     end
+
+    context 'when unhandled exception is raised' do
+      let(:exception) { Class.new(StandardError) }
+
+      before do
+        expect(runner).to receive(:run).and_raise(exception)
+      end
+
+      it 'updates status to error' do
+        expect(Barbeque::JobExecution.count).to eq(0)
+        expect { handler.run }.to raise_error(exception)
+        expect(Barbeque::JobExecution.last).to be_error
+      end
+    end
   end
 end

--- a/spec/barbeque/message_handler/job_retry_spec.rb
+++ b/spec/barbeque/message_handler/job_retry_spec.rb
@@ -133,5 +133,21 @@ describe Barbeque::MessageHandler::JobRetry do
         expect { handler.run }.to raise_error(Barbeque::MessageHandler::DuplicatedExecution)
       end
     end
+
+    context 'when unhandled exception is raised' do
+      let(:exception) { Class.new(StandardError) }
+
+      before do
+        expect(runner).to receive(:run).and_raise(exception)
+      end
+
+      it 'updates status to error' do
+        expect(job_execution).to be_failed
+        expect(Barbeque::JobRetry.count).to eq(0)
+        expect { handler.run }.to raise_error(exception)
+        expect(Barbeque::JobRetry.last).to be_error
+        expect(job_execution.reload).to be_error
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, when unhandled exception is raised from custom runner, the
execution status remains "pending" and there's no way to retry it after
the exception is fixed.

@cookpad/dev-infra @k0kubun please review