### PR TITLE
Log message body for retry

### DIFF
--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -24,6 +24,7 @@ module Barbeque
           stdout, stderr, status = run_command
         rescue Exception => e
           job_execution.update!(status: :error, finished_at: Time.now)
+          log_result(job_execution, '', '')
           notify_slack(job_execution)
           raise e
         end

--- a/lib/barbeque/message_handler/job_retry.rb
+++ b/lib/barbeque/message_handler/job_retry.rb
@@ -28,6 +28,7 @@ module Barbeque
         rescue Exception => e
           job_retry.update!(status: :error, finished_at: Time.now)
           job_execution.update!(status: :error)
+          log_result(job_retry, '', '')
           notify_slack(job_retry)
           raise e
         end

--- a/spec/barbeque/message_handler/job_execution_spec.rb
+++ b/spec/barbeque/message_handler/job_execution_spec.rb
@@ -129,6 +129,14 @@ describe Barbeque::MessageHandler::JobExecution do
         expect { handler.run }.to raise_error(exception)
         expect(Barbeque::JobExecution.last).to be_error
       end
+
+      it 'logs message body' do
+        expect(Barbeque::ExecutionLog).to receive(:save).with(
+          execution: a_kind_of(Barbeque::JobExecution),
+          log: { message: message.body.to_json, stdout: '', stderr: '' },
+        )
+        expect { handler.run }.to raise_error(exception)
+      end
     end
   end
 end

--- a/spec/barbeque/message_handler/job_retry_spec.rb
+++ b/spec/barbeque/message_handler/job_retry_spec.rb
@@ -148,6 +148,14 @@ describe Barbeque::MessageHandler::JobRetry do
         expect(Barbeque::JobRetry.last).to be_error
         expect(job_execution.reload).to be_error
       end
+
+      it 'logs empty output' do
+        expect(Barbeque::ExecutionLog).to receive(:save).with(
+          execution: a_kind_of(Barbeque::JobRetry),
+          log: { stdout: '', stderr: '' },
+        )
+        expect { handler.run }.to raise_error(exception)
+      end
     end
   end
 end


### PR DESCRIPTION
In order to retry errored job_execution, we have to log the message body
to S3.
Logging in job_retry isn't necessary here, but I decided to log empty
result for consistency.

@cookpad/dev-infra @k0kubun Please review