### PR TITLE
Support JSON-formatted string as messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ branches:
     - master
 rvm:
   - ruby-head
-  - 2.3.1
+  - 2.4.1
+  - 2.3.4
   - 2.2.5
 script:
   # To resolve: Mysql2::Error: Specified key was too long; max key length is 767 bytes

--- a/lib/barbeque/message/job_execution.rb
+++ b/lib/barbeque/message/job_execution.rb
@@ -13,11 +13,7 @@ module Barbeque
         super
         @application = message_body['Application']
         @job  = message_body['Job']
-        @body = if message_body['Message'].is_a?(String)
-                  JSON.parse(message_body['Message'])
-                else
-                  message_body['Message']
-                end
+        @body = message_body['Message']
       end
     end
   end

--- a/lib/barbeque/message/job_execution.rb
+++ b/lib/barbeque/message/job_execution.rb
@@ -13,7 +13,11 @@ module Barbeque
         super
         @application = message_body['Application']
         @job  = message_body['Job']
-        @body = message_body['Message']
+        @body = if message_body['Message'].is_a?(String)
+                  JSON.parse(message_body['Message'])
+                else
+                  message_body['Message']
+                end
       end
     end
   end

--- a/lib/barbeque/message/notification.rb
+++ b/lib/barbeque/message/notification.rb
@@ -21,11 +21,7 @@ module Barbeque
       def assign_body(message_body)
         super
         @topic_arn = message_body['TopicArn']
-        @body = if message_body['Message'].is_a?(String)
-                  JSON.parse(message_body['Message'])
-                else
-                  message_body['Message']
-                end
+        @body = JSON.parse(message_body['Message'])
       end
     end
   end

--- a/lib/barbeque/message/notification.rb
+++ b/lib/barbeque/message/notification.rb
@@ -21,7 +21,11 @@ module Barbeque
       def assign_body(message_body)
         super
         @topic_arn = message_body['TopicArn']
-        @body = message_body['Message']
+        @body = if message_body['Message'].is_a?(String)
+                  JSON.parse(message_body['Message'])
+                else
+                  message_body['Message']
+                end
       end
     end
   end

--- a/spec/barbeque/message_handler/notification_spec.rb
+++ b/spec/barbeque/message_handler/notification_spec.rb
@@ -9,7 +9,7 @@ describe Barbeque::MessageHandler::Notification do
         Aws::SQS::Types::Message.new(message_id: SecureRandom.uuid, receipt_handle: 'dummy receipt handle'),
         {
           'TopicArn'  => sns_subscription.topic_arn,
-          'Message'   => ['hello'],
+          'Message'   => ['hello'].to_json,
         }
       )
     end

--- a/spec/barbeque/message_spec.rb
+++ b/spec/barbeque/message_spec.rb
@@ -66,6 +66,7 @@ describe Barbeque::Message::Base do
 
   context 'given Notification' do
     let(:sns_subscription) { create(:sns_subscription, job_queue: job_queue) }
+    let(:message_body) { { "foo" => "bar" }.to_json }
     let(:raw_sqs_message) do
       {
         'Type'     => 'Notification',
@@ -79,20 +80,8 @@ describe Barbeque::Message::Base do
       expect(message).to be_a(Barbeque::Message::Notification)
       expect(message.id).to eq(message_id)
       expect(message.receipt_handle).to eq(receipt_handle)
-      expect(message.body).to eq(message_body)
+      expect(message.body).to eq({ "foo" => "bar" })
       expect(message.topic_arn).to eq(sns_subscription.topic_arn)
-    end
-
-    context 'given JSON formatted string as message_body' do
-      let(:message_body) { { "foo" => "bar" }.to_json }
-      it 'parses a SQS message' do
-        message = Barbeque::Message.parse(sqs_message)
-        expect(message).to be_a(Barbeque::Message::Notification)
-        expect(message.id).to eq(message_id)
-        expect(message.receipt_handle).to eq(receipt_handle)
-        expect(message.body).to eq({ "foo" => "bar" })
-        expect(message.topic_arn).to eq(sns_subscription.topic_arn)
-      end
     end
   end
 

--- a/spec/barbeque/message_spec.rb
+++ b/spec/barbeque/message_spec.rb
@@ -33,18 +33,6 @@ describe Barbeque::Message::Base do
       expect(message.receipt_handle).to eq(receipt_handle)
       expect(message.body).to eq(message_body)
     end
-
-    context 'given JSON formatted string as message_body' do
-      let(:message_body) { { "foo" => "bar" }.to_json }
-      it 'parses a SQS message' do
-        message = Barbeque::Message.parse(sqs_message)
-        expect(message.application).to eq(application)
-        expect(message.job).to eq(job)
-        expect(message.id).to eq(message_id)
-        expect(message.receipt_handle).to eq(receipt_handle)
-        expect(message.body).to eq({ "foo" => "bar" })
-      end
-    end
   end
 
   context 'given JobRetry' do

--- a/spec/barbeque/message_spec.rb
+++ b/spec/barbeque/message_spec.rb
@@ -6,7 +6,7 @@ describe Barbeque::Message::Base do
   let(:job)         { 'NotifyAuthor' }
   let(:job_queue) { create(:job_queue) }
   let(:message_id)  { SecureRandom.uuid }
-  let(:message_body) { '{"foo":"bar"}' }
+  let(:message_body) { { "foo" => "bar" } }
   let(:receipt_handle) do
     "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw
     Lj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QE
@@ -32,6 +32,18 @@ describe Barbeque::Message::Base do
       expect(message.id).to eq(message_id)
       expect(message.receipt_handle).to eq(receipt_handle)
       expect(message.body).to eq(message_body)
+    end
+
+    context 'given JSON formatted string as message_body' do
+      let(:message_body) { { "foo" => "bar" }.to_json }
+      it 'parses a SQS message' do
+        message = Barbeque::Message.parse(sqs_message)
+        expect(message.application).to eq(application)
+        expect(message.job).to eq(job)
+        expect(message.id).to eq(message_id)
+        expect(message.receipt_handle).to eq(receipt_handle)
+        expect(message.body).to eq({ "foo" => "bar" })
+      end
     end
   end
 
@@ -69,6 +81,18 @@ describe Barbeque::Message::Base do
       expect(message.receipt_handle).to eq(receipt_handle)
       expect(message.body).to eq(message_body)
       expect(message.topic_arn).to eq(sns_subscription.topic_arn)
+    end
+
+    context 'given JSON formatted string as message_body' do
+      let(:message_body) { { "foo" => "bar" }.to_json }
+      it 'parses a SQS message' do
+        message = Barbeque::Message.parse(sqs_message)
+        expect(message).to be_a(Barbeque::Message::Notification)
+        expect(message.id).to eq(message_id)
+        expect(message.receipt_handle).to eq(receipt_handle)
+        expect(message.body).to eq({ "foo" => "bar" })
+        expect(message.topic_arn).to eq(sns_subscription.topic_arn)
+      end
     end
   end
 


### PR DESCRIPTION
Using BarbequeClient for enqueuing a message, it might be Array or Hash
because it is posted as JSON format with `Content-Type: application/json` header.
However in some cases, e.g. posted as query parameter style or enqueued
via SNS subscriptions, the message comes as JSON-formatted string. So
this patch make a message which is String parse as JSON.

@cookpad/dev-infra @k0kubun How do you think about it?