### PR TITLE
Show application names for each job in sns_subscriptions#new

### DIFF
--- a/app/views/barbeque/sns_subscriptions/_form.html.haml
+++ b/app/views/barbeque/sns_subscriptions/_form.html.haml
@@ -32,7 +32,7 @@
       .row.form-group
         .col-md-4
           = f.label :job_definition_id
-          = f.collection_select :job_definition_id, Barbeque::JobDefinition.pluck(:id, :job), :first, :second,
+          = f.collection_select :job_definition_id, Barbeque::JobDefinition.all.map {|definition| [definition.id, "#{definition.app.name} - #{definition.job}"] }, :first, :second,
             { prompt: true }, class: 'form-control'
 
       .form-group


### PR DESCRIPTION
I modify a list of job definitions to `AppName - JobName` style in forms for SNS subscriptions.

![image](https://cloud.githubusercontent.com/assets/34493/26812341/18dc0282-4ab2-11e7-9f72-480e90ca11a9.png)

@cookpad/dev-infra @k0kubun How do you think about it?