### PR TITLE
Add running status

### DIFF
--- a/app/helpers/barbeque/job_executions_helper.rb
+++ b/app/helpers/barbeque/job_executions_helper.rb
@@ -12,6 +12,8 @@ module Barbeque::JobExecutionsHelper
         'info'
       when 'error'
         'danger'
+      when 'running'
+        'info'
       else
         'default'
       end

--- a/app/models/barbeque/job_execution.rb
+++ b/app/models/barbeque/job_execution.rb
@@ -11,6 +11,7 @@ class Barbeque::JobExecution < Barbeque::ApplicationRecord
     failed:  2,
     retried: 3,
     error: 4,
+    running: 5,
   }
 
   paginates_per 15

--- a/app/models/barbeque/job_retry.rb
+++ b/app/models/barbeque/job_retry.rb
@@ -10,6 +10,7 @@ class Barbeque::JobRetry < Barbeque::ApplicationRecord
     failed:  2,
     retried: 3,
     error: 4,
+    running: 5,
   }
 
   # @return [Hash] - A hash created by `JobExecutor::Retry#log_result`

--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -19,6 +19,7 @@ module Barbeque
         rescue ActiveRecord::RecordNotUnique => e
           raise DuplicatedExecution.new(e.message)
         end
+        job_execution.update!(status: :running)
 
         begin
           stdout, stderr, status = run_command

--- a/lib/barbeque/message_handler/job_retry.rb
+++ b/lib/barbeque/message_handler/job_retry.rb
@@ -21,7 +21,8 @@ module Barbeque
         rescue ActiveRecord::RecordNotUnique => e
           raise DuplicatedExecution.new(e.message)
         end
-        job_execution.update!(status: 'retried')
+        job_execution.update!(status: :retried)
+        job_retry.update!(status: :running)
 
         begin
           stdout, stderr, result = run_command

--- a/spec/barbeque/message_handler/job_execution_spec.rb
+++ b/spec/barbeque/message_handler/job_execution_spec.rb
@@ -61,6 +61,19 @@ describe Barbeque::MessageHandler::JobExecution do
       handler.run
     end
 
+    it 'sets running status during run_command' do
+      expect(Barbeque::JobExecution.count).to eq(0)
+      expect(runner).to receive(:run) { |command, envs|
+        expect(command).to eq(job_definition.command)
+        expect(Barbeque::JobExecution.count).to eq(1)
+        expect(Barbeque::JobExecution.last).to be_running
+        ['stdout', 'stderr', status]
+      }
+      handler.run
+      expect(Barbeque::JobExecution.count).to eq(1)
+      expect(Barbeque::JobExecution.last).to_not be_running
+    end
+
     context 'when job succeeded' do
       it 'sets job_executions.status :success' do
         handler.run

--- a/spec/barbeque/message_handler/job_retry_spec.rb
+++ b/spec/barbeque/message_handler/job_retry_spec.rb
@@ -46,6 +46,18 @@ describe Barbeque::MessageHandler::JobRetry do
       handler.run
     end
 
+    it 'sets running status during run_command' do
+      expect(Barbeque::JobRetry.count).to eq(0)
+      expect(runner).to receive(:run) { |command, envs|
+        expect(command).to eq(job_definition.command)
+        expect(Barbeque::JobRetry.count).to eq(1)
+        expect(Barbeque::JobRetry.last).to be_running
+        ['stdout', 'stderr', status]
+      }
+      handler.run
+      expect(Barbeque::JobRetry.count).to eq(1)
+      expect(Barbeque::JobRetry.last).to_not be_running
+    end
     it 'logs stdout and stderr to S3' do
       expect(Barbeque::ExecutionLog).to receive(:save).with(
         execution: a_kind_of(Barbeque::JobRetry),


### PR DESCRIPTION
Barbeque execution makes transition as follows.

1. Enqueued to SQS
2. Dequeued from SQS
3. Start command
4. Finish command

I'd like to distinguish status between 2 and 3 from Web console; i.e.,
the execution is running or not. Executions only in 2 status should be
called as "pending" in my opinion.

@k0kubun @cookpad/dev-infra please review