### PR TITLE
Change S3 log format

### DIFF
--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -38,8 +38,8 @@ module Barbeque
       private
 
       def log_result(execution, stdout, stderr)
-        log = { message: @message.body.to_json, stdout: stdout, stderr: stderr }
-        Barbeque::ExecutionLog.save(execution: execution, log: log)
+        Barbeque::ExecutionLog.save_message(execution, @message)  # TODO: Should be saved earlier
+        Barbeque::ExecutionLog.save_stdout_and_stderr(execution, stdout, stderr)
       end
 
       def notify_slack(job_execution)

--- a/lib/barbeque/message_handler/job_retry.rb
+++ b/lib/barbeque/message_handler/job_retry.rb
@@ -44,8 +44,7 @@ module Barbeque
       private
 
       def log_result(job_retry, stdout, stderr)
-        log = { stdout: stdout, stderr: stderr }
-        Barbeque::ExecutionLog.save(execution: job_retry, log: log)
+        Barbeque::ExecutionLog.save_stdout_and_stderr(job_retry, stdout, stderr)
       end
 
       # @param [Barbeque::JobRetry] job_retry

--- a/spec/barbeque/message_handler/job_execution_spec.rb
+++ b/spec/barbeque/message_handler/job_execution_spec.rb
@@ -23,7 +23,8 @@ describe Barbeque::MessageHandler::JobExecution do
       docker_image = Barbeque::DockerImage.new(job_definition.app.docker_image)
       allow(Barbeque::DockerImage).to receive(:new).with(job_definition.app.docker_image).and_return(docker_image)
       allow(Barbeque::Runner::Docker).to receive(:new).with(docker_image: docker_image).and_return(runner)
-      allow(Barbeque::ExecutionLog).to receive(:save)
+      allow(Barbeque::ExecutionLog).to receive(:save_message)
+      allow(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr)
     end
 
     around do |example|
@@ -40,10 +41,8 @@ describe Barbeque::MessageHandler::JobExecution do
     end
 
     it 'logs message, stdout and stderr to S3' do
-      expect(Barbeque::ExecutionLog).to receive(:save).with(
-        execution: a_kind_of(Barbeque::JobExecution),
-        log: { message: message.body.to_json, stdout: 'stdout', stderr: 'stderr' },
-      )
+      expect(Barbeque::ExecutionLog).to receive(:save_message).with(a_kind_of(Barbeque::JobExecution), message)
+      expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(a_kind_of(Barbeque::JobExecution), 'stdout', 'stderr')
       handler.run
     end
 
@@ -144,10 +143,8 @@ describe Barbeque::MessageHandler::JobExecution do
       end
 
       it 'logs message body' do
-        expect(Barbeque::ExecutionLog).to receive(:save).with(
-          execution: a_kind_of(Barbeque::JobExecution),
-          log: { message: message.body.to_json, stdout: '', stderr: '' },
-        )
+        expect(Barbeque::ExecutionLog).to receive(:save_message).with(a_kind_of(Barbeque::JobExecution), message)
+        expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(a_kind_of(Barbeque::JobExecution), '', '')
         expect { handler.run }.to raise_error(exception)
       end
     end

--- a/spec/barbeque/message_handler/job_retry_spec.rb
+++ b/spec/barbeque/message_handler/job_retry_spec.rb
@@ -18,7 +18,7 @@ describe Barbeque::MessageHandler::JobRetry do
     let(:runner) { double('Barbeque::Runner::Docker', run: ['stdout', 'stderr', status]) }
 
     before do
-      allow(Barbeque::ExecutionLog).to receive(:save)
+      allow(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr)
       allow(Barbeque::ExecutionLog).to receive(:load).with(execution: job_execution).and_return({ 'message' => message_body })
 
       docker_image = Barbeque::DockerImage.new(job_definition.app.docker_image)
@@ -59,10 +59,7 @@ describe Barbeque::MessageHandler::JobRetry do
       expect(Barbeque::JobRetry.last).to_not be_running
     end
     it 'logs stdout and stderr to S3' do
-      expect(Barbeque::ExecutionLog).to receive(:save).with(
-        execution: a_kind_of(Barbeque::JobRetry),
-        log: { stdout: 'stdout', stderr: 'stderr' },
-      )
+      expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(a_kind_of(Barbeque::JobRetry), 'stdout', 'stderr')
       handler.run
     end
 
@@ -162,10 +159,7 @@ describe Barbeque::MessageHandler::JobRetry do
       end
 
       it 'logs empty output' do
-        expect(Barbeque::ExecutionLog).to receive(:save).with(
-          execution: a_kind_of(Barbeque::JobRetry),
-          log: { stdout: '', stderr: '' },
-        )
+        expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(a_kind_of(Barbeque::JobRetry), '', '')
         expect { handler.run }.to raise_error(exception)
       end
     end


### PR DESCRIPTION
I'm planning to change the timing when message body is stored to S3
because it's currently hard to recover from unexpected errors during job
executions. If the message was stored to S3 before starting job
executions, it might be possible to retry the enqueued job even if the
Barbeque worker host goes down or the database server goes down while
running the job.

In order to change the timing, I'd like to split the log file because
message body can be stored before job execution but stdout and stderr
cannot be stored before job execution.

----

@cookpad/dev-infra @k0kubun please review