### PR TITLE
Pass job execution to executor

### DIFF
--- a/lib/barbeque/executor.rb
+++ b/lib/barbeque/executor.rb
@@ -4,10 +4,9 @@ require 'barbeque/executor/hako'
 
 module Barbeque
   module Executor
-    # @param [Barbeque::DockerImage] docker_image
-    def self.create(docker_image:)
+    def self.create
       klass = const_get(Barbeque.config.executor, false)
-      klass.new(Barbeque.config.executor_options.merge(docker_image: docker_image))
+      klass.new(Barbeque.config.executor_options)
     end
   end
 end

--- a/lib/barbeque/executor/docker.rb
+++ b/lib/barbeque/executor/docker.rb
@@ -1,27 +1,28 @@
+require 'barbeque/docker_image'
 require 'open3'
 
 module Barbeque
   module Executor
     class Docker
-      # @param [Barbeque::DockerImage] docker_image
-      def initialize(docker_image:)
-        @docker_image = docker_image.to_s
+      def initialize(_options)
       end
 
-      # @param [Array<String>] command
+      # @param [Barbeque::JobExecution] job_execution
       # @param [Hash] envs
       # @return [String] stdout
       # @return [String] stderr
       # @return [Process::Status] status
-      def run(command, envs)
-        cmd = build_docker_run_command(command, envs)
+      def run(job_execution, envs)
+        job_definition = job_execution.job_definition
+        docker_image = DockerImage.new(job_definition.app.docker_image)
+        cmd = build_docker_run_command(docker_image, command, envs)
         Bundler.with_clean_env { Open3.capture3(*cmd) }
       end
 
       private
 
-      def build_docker_run_command(command, envs)
-        ['docker', 'run', *env_options(envs), @docker_image, *command]
+      def build_docker_run_command(docker_image, command, envs)
+        ['docker', 'run', *env_options(envs), docker_image.to_s, *command]
       end
 
       def env_options(envs)

--- a/spec/barbeque/executor_spec.rb
+++ b/spec/barbeque/executor_spec.rb
@@ -3,8 +3,6 @@ require 'barbeque/executor'
 
 describe Barbeque::Executor do
   describe '.create' do
-    let(:docker_image) { 'cookpad' }
-
     before do
       config = Barbeque.build_config(barbeque_yml)
       allow(Barbeque).to receive(:config).and_return(config)
@@ -13,25 +11,22 @@ describe Barbeque::Executor do
     context 'without executor_options' do
       let(:barbeque_yml) { 'barbeque' }
 
-      it 'initializes a configured executor with docker_image' do
-        expect(Barbeque::Executor::Docker).to receive(:new).with(
-          docker_image: docker_image,
-        )
-        Barbeque::Executor.create(docker_image: docker_image)
+      it 'initializes a configured executor' do
+        expect(Barbeque::Executor::Docker).to receive(:new).with({})
+        Barbeque::Executor.create
       end
     end
 
     context 'with executor_options' do
       let(:barbeque_yml) { 'barbeque.hako' }
 
-      it 'initializes a configured executor with docker_image and configured options' do
+      it 'initializes a configured executor with configured options' do
         expect(Barbeque::Executor::Hako).to receive(:new).with(
-          docker_image: docker_image,
           hako_dir: '/home/k0kubun/hako_repo',
           hako_env: { 'ACCESS_TOKEN' => 'token' },
           yaml_dir: '/yamls'
         )
-        Barbeque::Executor.create(docker_image: docker_image)
+        Barbeque::Executor.create
       end
     end
   end


### PR DESCRIPTION
In order to achieve #32 , executor should have more control on job executions.
So I let executor receive job execution and build docker_image and command from it.

@cookpad/dev-infra @k0kubun please review