### PR TITLE
Set shorter wait time for SQS polling

### DIFF
--- a/app/controllers/barbeque/job_queues_controller.rb
+++ b/app/controllers/barbeque/job_queues_controller.rb
@@ -1,3 +1,5 @@
+require 'barbeque/config'
+
 class Barbeque::JobQueuesController < Barbeque::ApplicationController
   def index
     @job_queues = Barbeque::JobQueue.all
@@ -49,9 +51,7 @@ class Barbeque::JobQueuesController < Barbeque::ApplicationController
     Aws::SQS::Client.new.create_queue(
       queue_name: job_queue.sqs_queue_name,
       attributes: {
-        # All SQS queues' "ReceiveMessageWaitTimeSeconds" are configured to 10s.
-        # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
-        'ReceiveMessageWaitTimeSeconds' => Barbeque::JobQueue::SQS_RECEIVE_MESSAGE_WAIT_TIME.to_s,
+        'ReceiveMessageWaitTimeSeconds' => Barbeque.config.sqs_receive_message_wait_time.to_s,
       },
     )
   end

--- a/app/controllers/barbeque/job_queues_controller.rb
+++ b/app/controllers/barbeque/job_queues_controller.rb
@@ -49,8 +49,7 @@ class Barbeque::JobQueuesController < Barbeque::ApplicationController
     Aws::SQS::Client.new.create_queue(
       queue_name: job_queue.sqs_queue_name,
       attributes: {
-        # All SQS queues' "ReceiveMessageWaitTimeSeconds" are configured to be 20s (maximum).
-        # This should be as large as possible to reduce API-calling cost by long polling.
+        # All SQS queues' "ReceiveMessageWaitTimeSeconds" are configured to 10s.
         # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
         'ReceiveMessageWaitTimeSeconds' => Barbeque::JobQueue::SQS_RECEIVE_MESSAGE_WAIT_TIME.to_s,
       },

--- a/app/models/barbeque/job_queue.rb
+++ b/app/models/barbeque/job_queue.rb
@@ -4,10 +4,6 @@ class Barbeque::JobQueue < Barbeque::ApplicationRecord
 
   has_many :sns_subscriptions, class_name: 'SNSSubscription', dependent: :destroy
 
-  # All SQS queues' "ReceiveMessageWaitTimeSeconds" are configured to 10s.
-  # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
-  SQS_RECEIVE_MESSAGE_WAIT_TIME = 10
-
   # SQS queue allows [a-zA-Z0-9_-]+ as queue name. Its maximum length is 80.
   validates :name, presence: true, uniqueness: true, format: /\A[a-zA-Z0-9_-]+\z/,
     length: { maximum: SQS_NAME_MAX_LENGTH - SQS_NAME_PREFIX.length }

--- a/app/models/barbeque/job_queue.rb
+++ b/app/models/barbeque/job_queue.rb
@@ -4,10 +4,9 @@ class Barbeque::JobQueue < Barbeque::ApplicationRecord
 
   has_many :sns_subscriptions, class_name: 'SNSSubscription', dependent: :destroy
 
-  # All SQS queues' "ReceiveMessageWaitTimeSeconds" are configured to be 20s (maximum).
-  # This should be as large as possible to reduce API-calling cost by long polling.
+  # All SQS queues' "ReceiveMessageWaitTimeSeconds" are configured to 10s.
   # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
-  SQS_RECEIVE_MESSAGE_WAIT_TIME = 20
+  SQS_RECEIVE_MESSAGE_WAIT_TIME = 10
 
   # SQS queue allows [a-zA-Z0-9_-]+ as queue name. Its maximum length is 80.
   validates :name, presence: true, uniqueness: true, format: /\A[a-zA-Z0-9_-]+\z/,

--- a/lib/barbeque/config.rb
+++ b/lib/barbeque/config.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 module Barbeque
   class Config
-    attr_accessor :exception_handler, :executor, :executor_options
+    attr_accessor :exception_handler, :executor, :executor_options, :sqs_receive_message_wait_time
 
     def initialize(options = {})
       options.each do |key, value|
@@ -22,6 +22,8 @@ module Barbeque
       'exception_handler' => 'RailsLogger',
       'executor' => 'Docker',
       'executor_options' => {},
+      # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
+      'sqs_receive_message_wait_time' => 10,
     }
 
     def config

--- a/lib/barbeque/message_queue.rb
+++ b/lib/barbeque/message_queue.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk'
+require 'barbeque/config'
 require 'barbeque/message'
 
 module Barbeque
@@ -36,7 +37,7 @@ module Barbeque
     def receive_messages
       result = client.receive_message(
         queue_url: @job_queue.queue_url,
-        wait_time_seconds: Barbeque::JobQueue::SQS_RECEIVE_MESSAGE_WAIT_TIME,
+        wait_time_seconds: Barbeque.config.sqs_receive_message_wait_time,
       )
       result.messages.map { |m| Barbeque::Message.parse(m) }
     end

--- a/spec/controllers/barbeque/job_queues_controller_spec.rb
+++ b/spec/controllers/barbeque/job_queues_controller_spec.rb
@@ -58,7 +58,7 @@ describe Barbeque::JobQueuesController do
     it 'creates SQS queue' do
       expect(sqs_client).to receive(:create_queue).with(
         queue_name: queue_name,
-        attributes: { 'ReceiveMessageWaitTimeSeconds' => Barbeque::JobQueue::SQS_RECEIVE_MESSAGE_WAIT_TIME.to_s },
+        attributes: { 'ReceiveMessageWaitTimeSeconds' => Barbeque.config.sqs_receive_message_wait_time.to_s },
       )
       post :create, params: { job_queue: attributes }
       expect(Barbeque::JobQueue.last.queue_url).to eq(queue_url)


### PR DESCRIPTION
Setting longer wait time is good for reducing API calls, but longer wait
time do harm to quick shutdown of barbeque-worker, which leads to longer
deployment time. I think 10s is long enough to avoid too-frequent API
calls.

----

This patch is related to #32 a bit (but not a requirement).
Making deployment time shorter is good for ECS services. ECS's time limit is 30s.

@cookpad/dev-infra @k0kubun What do you think?