### PR TITLE
Introduce Executor as a replacement of Runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
       - In Executor::Docker, uses S3 task notification JSON
     - RetryPoller: polls retry status and reflect it to the database
       - Same with ExecutionPoller
+  - Add `maximum_concurrent_executions` configuration to config/barbeque.yml
+    - It controls the number of concurrent job executions
+    - The limit is disabled by default
 - Add `sqs_receive_message_wait_time` configuration to config/barbeque.yml
   - This option controls ReceiveMessageWaitTimeSeconds attribute of SQS queue
   - The default value is changed from 20s to 10s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 ## v1.0.0 (xxxx-xx-xx)
+- Introduce Executor as a replacement of Runner
+  - `runner` and `runner_options` is renamed to `executor` and `executor_options` respectively
+  - Now `rake barbeque:worker` launches three types of process
+    - Runner: receives message from SQS queue, starts job execution and stores its identifier to the database
+      - In Executor::Docker, the identifier is container id
+      - In Executor::Hako, the identifier is ECS cluster and task ARN
+    - ExecutionPoller: polls execution status and reflect it to the database
+      - In Executor::Docker, uses `docker inspect` command
+      - In Executor::Docker, uses S3 task notification JSON
+    - RetryPoller: polls retry status and reflect it to the database
+      - Same with ExecutionPoller
 - Add `sqs_receive_message_wait_time` configuration to config/barbeque.yml
   - This option controls ReceiveMessageWaitTimeSeconds attribute of SQS queue
   - The default value is changed from 20s to 10s

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In Barbeque worker, they are done on Docker container.
 ## Why Barbeque?
 
 - You can achieve job-level auto scaling using tools like [Amazon ECS](https://aws.amazon.com/ecs/) [EC2 Auto Scaling group](https://aws.amazon.com/autoscaling/)
-  - For Amazon ECS, Barbeque has Hako runner
+  - For Amazon ECS, Barbeque has Hako executor
 - You don't have to manage infrastructure for each application like Resque or Sidekiq
 
 For details, see [Scalable Job Queue System Built with Docker // Speaker Deck](https://speakerdeck.com/k0kubun/scalable-job-queue-system-built-with-docker).
@@ -45,6 +45,15 @@ You also need to prepare MySQL, Amazon SQS and Amazon S3.
 $ rake barbeque:worker BARBEQUE_QUEUE=default
 ```
 
+The rake task launches four worker processes.
+
+- Two runners
+  - receives message from SQS queue, starts job execution and stores its identifier to the database
+- One execution poller
+  - gets execution status and reflect it to the database
+- One retry poller
+  - gets retried execution status and reflect it to the database
+
 ## Usage
 
 Web API documentation is available at [doc/toc.md](./doc/toc.md).
@@ -52,6 +61,22 @@ Web API documentation is available at [doc/toc.md](./doc/toc.md).
 ### Ruby
 
 [barbeque\_client.gem](https://github.com/cookpad/barbeque_client) has API client and ActiveJob integration.
+
+## Executor
+Barbeque executor can be customized in config/barbeque.yml. Executor is responsible for starting executions and getting status of executions.
+
+Barbeque has currently two executors.
+
+### Docker (default)
+Barbeque::Executor::Docker starts execution by `docker run --detach` and gets status by `docker inspect`.
+
+### Hako
+Barbeque::Executor::Hako starts execution by `hako oneshot --no-wait` and gets status from S3 task notification.
+
+#### Requirement
+You must configure CloudWatch Events for putting S3 task notification.
+See Hako's documentation for detail.
+https://github.com/eagletmt/hako/blob/master/docs/ecs-task-notification.md
 
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/app/models/barbeque/docker_container.rb
+++ b/app/models/barbeque/docker_container.rb
@@ -1,0 +1,2 @@
+class Barbeque::DockerContainer < Barbeque::ApplicationRecord
+end

--- a/app/models/barbeque/ecs_hako_task.rb
+++ b/app/models/barbeque/ecs_hako_task.rb
@@ -1,0 +1,2 @@
+class Barbeque::EcsHakoTask < Barbeque::ApplicationRecord
+end

--- a/db/migrate/20170711085157_create_barbeque_docker_containers.rb
+++ b/db/migrate/20170711085157_create_barbeque_docker_containers.rb
@@ -1,0 +1,12 @@
+class CreateBarbequeDockerContainers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :barbeque_docker_containers, options: 'ENGINE=InnoDB ROW_FORMAT=dynamic DEFAULT CHARSET=utf8mb4' do |t|
+      t.string :message_id, null: false
+      t.string :container_id, null: false
+
+      t.timestamps
+
+      t.index ['message_id'], unique: true
+    end
+  end
+end

--- a/db/migrate/20170712075449_create_barbeque_ecs_hako_tasks.rb
+++ b/db/migrate/20170712075449_create_barbeque_ecs_hako_tasks.rb
@@ -1,0 +1,13 @@
+class CreateBarbequeEcsHakoTasks < ActiveRecord::Migration[5.0]
+  def change
+    create_table :barbeque_ecs_hako_tasks, options: 'ENGINE=InnoDB ROW_FORMAT=dynamic DEFAULT CHARSET=utf8mb4' do |t|
+      t.string :message_id, null: false
+      t.string :cluster, null: false
+      t.string :task_arn, null: false
+
+      t.timestamps
+
+      t.index ['message_id'], unique: true
+    end
+  end
+end

--- a/lib/barbeque/config.rb
+++ b/lib/barbeque/config.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 module Barbeque
   class Config
-    attr_accessor :exception_handler, :executor, :executor_options, :sqs_receive_message_wait_time, :maximum_concurrent_executions
+    attr_accessor :exception_handler, :executor, :executor_options, :sqs_receive_message_wait_time, :maximum_concurrent_executions, :runner_wait_seconds
 
     def initialize(options = {})
       options.each do |key, value|
@@ -26,6 +26,7 @@ module Barbeque
       'sqs_receive_message_wait_time' => 10,
       # nil means unlimited
       'maximum_concurrent_executions' => nil,
+      'runner_wait_seconds' => 10,
     }
 
     def config

--- a/lib/barbeque/config.rb
+++ b/lib/barbeque/config.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 module Barbeque
   class Config
-    attr_accessor :exception_handler, :executor, :executor_options, :sqs_receive_message_wait_time
+    attr_accessor :exception_handler, :executor, :executor_options, :sqs_receive_message_wait_time, :maximum_concurrent_executions
 
     def initialize(options = {})
       options.each do |key, value|
@@ -24,6 +24,8 @@ module Barbeque
       'executor_options' => {},
       # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
       'sqs_receive_message_wait_time' => 10,
+      # nil means unlimited
+      'maximum_concurrent_executions' => nil,
     }
 
     def config

--- a/lib/barbeque/execution_poller.rb
+++ b/lib/barbeque/execution_poller.rb
@@ -1,8 +1,15 @@
 module Barbeque
   class ExecutionPoller
+    def initialize
+      @stop_requested = false
+    end
+
     def run
       Barbeque::JobExecution.running.find_in_batches do |job_executions|
         job_executions.shuffle.each do |job_execution|
+          if @stop_requested
+            return
+          end
           job_execution.with_lock do
             if job_execution.running?
               poll(job_execution)
@@ -14,6 +21,7 @@ module Barbeque
     end
 
     def stop
+      @stop_requested = true
     end
 
     private

--- a/lib/barbeque/execution_poller.rb
+++ b/lib/barbeque/execution_poller.rb
@@ -1,0 +1,26 @@
+module Barbeque
+  class ExecutionPoller
+    def run
+      Barbeque::JobExecution.running.find_in_batches do |job_executions|
+        job_executions.shuffle.each do |job_execution|
+          job_execution.with_lock do
+            if job_execution.running?
+              poll(job_execution)
+            end
+          end
+        end
+      end
+      sleep 1
+    end
+
+    def stop
+    end
+
+    private
+
+    def poll(job_execution)
+      executor = Executor.create
+      executor.poll_execution(job_execution)
+    end
+  end
+end

--- a/lib/barbeque/executor.rb
+++ b/lib/barbeque/executor.rb
@@ -3,6 +3,23 @@ require 'barbeque/executor/docker'
 require 'barbeque/executor/hako'
 
 module Barbeque
+  # Executor is responsible for starting executions and getting status of
+  # executions.
+  # Each executor must implement these methods.
+  # - #initialize(options)
+  #   - Create a executor with executor_options specified in config/barbeque.yml.
+  # - #start_execution(job_execution, envs)
+  #   - Start execution with environment variables. An executor must update the
+  #     execution status from pending.
+  # - #poll_execution(job_execution)
+  #   - Get the execution status and update the job_execution columns.
+  # - #start_retry(job_retry, envs)
+  #   - Start retry with environment variables. An executor must update the
+  #     retry status from pending and the corresponding execution status.
+  # - #poll_retry(job_retry)
+  #   - Get the execution status and update the job_retry and job_execution
+  #     columns.
+
   module Executor
     def self.create
       klass = const_get(Barbeque.config.executor, false)

--- a/lib/barbeque/executor/docker.rb
+++ b/lib/barbeque/executor/docker.rb
@@ -101,7 +101,7 @@ module Barbeque
         if status.success?
           begin
             JSON.parse(stdout)[0]
-          rescue => e
+          rescue JSON::ParserError => e
             raise DockerCommandError.new("Unable to parse JSON: #{e.class}: #{e.message}: #{stdout}")
           end
         else

--- a/lib/barbeque/executor/docker.rb
+++ b/lib/barbeque/executor/docker.rb
@@ -1,33 +1,123 @@
 require 'barbeque/docker_image'
+require 'barbeque/slack_notifier'
 require 'open3'
 
 module Barbeque
   module Executor
     class Docker
+      class DockerCommandError < StandardError
+      end
+
       def initialize(_options)
       end
 
       # @param [Barbeque::JobExecution] job_execution
       # @param [Hash] envs
-      # @return [String] stdout
-      # @return [String] stderr
-      # @return [Process::Status] status
-      def run(job_execution, envs)
-        job_definition = job_execution.job_definition
-        docker_image = DockerImage.new(job_definition.app.docker_image)
-        cmd = build_docker_run_command(docker_image, command, envs)
-        Bundler.with_clean_env { Open3.capture3(*cmd) }
+      def start_execution(job_execution, envs)
+        docker_image = DockerImage.new(job_execution.job_definition.app.docker_image)
+        cmd = build_docker_run_command(docker_image, job_execution.job_definition.command, envs)
+        stdout, stderr, status = Open3.capture3(*cmd)
+        if status.success?
+          job_execution.update!(status: :running)
+          Barbeque::DockerContainer.create!(message_id: job_execution.message_id, container_id: stdout.chomp)
+        else
+          job_execution.update!(status: :failed, finished_at: Time.zone.now)
+          Barbeque::ExecutionLog.save_stdout_and_stderr(job_execution, stdout, stderr)
+          Barbeque::SlackNotifier.notify_job_execution(job_execution)
+        end
+      end
+
+      # @param [Barbeque::JobRetry] job_retry
+      # @param [Hash] envs
+      def start_retry(job_retry, envs)
+        job_execution = job_retry.job_execution
+        docker_image = DockerImage.new(job_execution.job_definition.app.docker_image)
+        cmd = build_docker_run_command(docker_image, job_execution.job_definition.command, envs)
+        stdout, stderr, status = Open3.capture3(*cmd)
+        if status.success?
+          job_execution.update!(status: :retried)
+          job_retry.update!(status: :running)
+          Barbeque::DockerContainer.create!(message_id: job_retry.message_id, container_id: stdout.chomp)
+        else
+          job_retry.update!(status: :failed, finished_at: Time.zone.now)
+          job_execution.update!(status: :failed)
+          Barbeque::ExecutionLog.save_stdout_and_stderr(job_retry, stdout, stderr)
+          Barbeque::SlackNotifier.notify_job_retry(job_retry)
+        end
+      end
+
+      # @param [Barbeque::JobExecution] job_execution
+      def poll_execution(job_execution)
+        container = Barbeque::DockerContainer.find_by!(message_id: job_execution.message_id)
+        info = inspect_container(container.container_id)
+        if info['State'] && info['State']['Status'] != 'running'
+          finished_at = Time.zone.parse(info['State']['FinishedAt'])
+          exit_code = info['State']['ExitCode']
+          job_execution.update!(status: exit_code == 0 ? :success : :failed, finished_at: finished_at)
+
+          stdout, stderr = get_logs(container.container_id)
+          Barbeque::ExecutionLog.save_stdout_and_stderr(job_execution, stdout, stderr)
+          Barbeque::SlackNotifier.notify_job_execution(job_execution)
+        end
+      end
+
+      # @param [Barbeque::JobRetry] job_retry
+      def poll_retry(job_retry)
+        container = Barbeque::DockerContainer.find_by!(message_id: job_retry.message_id)
+        job_execution = job_retry.job_execution
+        info = inspect_container(container.container_id)
+        if info['State'] && info['State']['Status'] != 'running'
+          finished_at = Time.zone.parse(info['State']['FinishedAt'])
+          exit_code = info['State']['ExitCode']
+          status = exit_code == 0 ? :success : :failed
+          job_retry.update!(status: status, finished_at: finished_at)
+          job_execution.update!(status: status)
+
+          stdout, stderr = get_logs(container.container_id)
+          Barbeque::ExecutionLog.save_stdout_and_stderr(job_retry, stdout, stderr)
+          Barbeque::SlackNotifier.notify_job_retry(job_retry)
+        end
       end
 
       private
 
+      # @param [Barbeque::DockerImage] docker_image
+      # @param [Array<String>] command
+      # @param [Hash] envs
       def build_docker_run_command(docker_image, command, envs)
-        ['docker', 'run', *env_options(envs), docker_image.to_s, *command]
+        ['docker', 'run', '--detach', *env_options(envs), docker_image.to_s, *command]
       end
 
       def env_options(envs)
         envs.flat_map do |key, value|
           ['--env', "#{key}=#{value}"]
+        end
+      end
+
+      # @param [String] container_id
+      # @return [Hash] container info
+      def inspect_container(container_id)
+        stdout, stderr, status = Open3.capture3('docker', 'inspect', container_id)
+        if status.success?
+          begin
+            JSON.parse(stdout)[0]
+          rescue => e
+            raise DockerCommandError.new("Unable to parse JSON: #{e.class}: #{e.message}: #{stdout}")
+          end
+        else
+          raise DockerCommandError.new("Unable to inspect Docker container #{container.container_id}: STDOUT: #{stdout}; STDERR: #{stderr}")
+        end
+      end
+
+      # @param [String] container_id
+      # @return [String] stdout
+      # @return [String] stderr
+      def get_logs(container_id)
+        stdout, stderr, status = Open3.capture3('docker', 'logs', container_id)
+        if status.success?
+          [stdout, stderr]
+        else
+          raise DockerCommandError.new("Unable to get Docker container logs #{container.container_id}: STDOUT: #{stdout}; STDERR: #{stderr}")
         end
       end
     end

--- a/lib/barbeque/executor/hako.rb
+++ b/lib/barbeque/executor/hako.rb
@@ -119,7 +119,7 @@ module Barbeque
       end
 
       def s3_client
-        @s3_client ||= Aws::S3::Client.new(region: @s3_region)
+        @s3_client ||= Aws::S3::Client.new(region: @s3_region, http_read_timeout: 5)
       end
 
       def get_stopped_result(hako_task)

--- a/lib/barbeque/executor/hako.rb
+++ b/lib/barbeque/executor/hako.rb
@@ -1,29 +1,101 @@
 require 'barbeque/docker_image'
+require 'barbeque/slack_notifier'
 require 'open3'
+require 'uri'
 
 module Barbeque
   module Executor
     class Hako
+      class HakoCommandError < StandardError
+      end
+
       # @param [String] hako_dir
       # @param [Hash] hako_env
       # @param [String] yaml_dir
-      def initialize(hako_dir:, hako_env: {}, yaml_dir:)
+      def initialize(hako_dir:, hako_env: {}, yaml_dir:, oneshot_notification_prefix:)
         @hako_dir = hako_dir
         @hako_env = hako_env
         @yaml_dir = yaml_dir
+        uri = URI.parse(oneshot_notification_prefix)
+        @s3_bucket = uri.host
+        @s3_prefix = uri.path.sub(%r{\A/}, '')
+        @s3_region = URI.decode_www_form(uri.query || '').to_h['region']
       end
 
       # @param [Barbeque::JobExecution] job_execution
       # @param [Hash] envs
-      # @return [String] stdout
-      # @return [String] stderr
-      # @return [Process::Status] status
-      def run(job_execution, envs)
-        job_definition = job_execution.job_definition
-        docker_image = DockerImage.new(job_definition.app.docker_image)
-        cmd = build_hako_oneshot_command(docker_image, job_definition.command, envs)
-        Bundler.with_clean_env do
-          Open3.capture3(@hako_env, *cmd, chdir: @hako_dir)
+      def start_execution(job_execution, envs)
+        docker_image = DockerImage.new(job_execution.job_definition.app.docker_image)
+        cmd = build_hako_oneshot_command(docker_image, job_execution.job_definition.command, envs)
+        stdout, stderr, status = Bundler.with_clean_env { Open3.capture3(@hako_env, *cmd, chdir: @hako_dir) }
+        if status.success?
+          job_execution.update!(status: :running)
+          cluster, task_arn = extract_task_info(stdout)
+          Barbeque::EcsHakoTask.create!(message_id: job_execution.message_id, cluster: cluster, task_arn: task_arn)
+          Barbeque::ExecutionLog.save_stdout_and_stderr(job_execution, stdout, stderr)
+        else
+          job_execution.update!(status: :failed, finished_at: Time.zone.now)
+          Barbeque::ExecutionLog.save_stdout_and_stderr(job_execution, stdout, stderr)
+          Barbeque::SlackNotifier.notify_job_execution(job_execution)
+        end
+      end
+
+      # @param [Barbeque::JobRetry] job_retry
+      # @param [Hash] envs
+      def start_retry(job_retry, envs)
+        job_execution = job_retry.job_execution
+        docker_image = DockerImage.new(job_execution.job_definition.app.docker_image)
+        cmd = build_hako_oneshot_command(docker_image, job_execution.job_definition.command, envs)
+        stdout, stderr, status = Bundler.with_clean_env { Open3.capture3(@hako_env, *cmd, chdir: @hako_dir) }
+        if status.success?
+          cluster, task_arn = extract_task_info(stdout)
+          job_execution.update!(status: :retried)
+          job_retry.update!(status: :running)
+          Barbeque::EcsHakoTask.create!(message_id: job_retry.message_id, cluster: cluster, task_arn: task_arn)
+          Barbeque::ExecutionLog.save_stdout_and_stderr(job_retry, stdout, stderr)
+        else
+          job_retry.update!(status: :failed, finished_at: Time.zone.now)
+          job_execution.update!(status: :failed)
+          Barbeque::ExecutionLog.save_stdout_and_stderr(job_retry, stdout, stderr)
+          Barbeque::SlackNotifier.notify_job_retry(job_retry)
+        end
+      end
+
+      # @param [Barbeque::JobExecution] job_execution
+      def poll_execution(job_execution)
+        hako_task = Barbeque::EcsHakoTask.find_by!(message_id: job_execution.message_id)
+        result = get_stopped_result(hako_task)
+        if result
+          detail = result.fetch('detail')
+          task = Aws::Json::Parser.new(Aws::ECS::Client.api.operation('describe_tasks').output.shape.member(:tasks).shape.member).parse(JSON.dump(detail))
+          status = :failed
+          task.containers.each do |container|
+            if container.name == 'app'
+              status = container.exit_code == 0 ? :success : :failed
+            end
+          end
+          job_execution.update!(status: status, finished_at: task.stopped_at)
+          Barbeque::SlackNotifier.notify_job_execution(job_execution)
+        end
+      end
+
+      # @param [Barbeque::JobRetry] job_execution
+      def poll_retry(job_retry)
+        hako_task = Barbeque::EcsHakoTask.find_by!(message_id: job_retry.message_id)
+        job_execution = job_retry.job_execution
+        result = get_stopped_result(hako_task)
+        if result
+          detail = result.fetch('detail')
+          task = Aws::Json::Parser.new(Aws::ECS::Client.api.operation('describe_tasks').output.shape.member(:tasks).shape.member).parse(JSON.dump(detail))
+          status = :failed
+          task.containers.each do |container|
+            if container.name == 'app'
+              status = container.exit_code == 0 ? :success : :failed
+            end
+          end
+          job_retry.update!(status: status, finished_at: task.stopped_at)
+          job_execution.update!(status: status)
+          Barbeque::SlackNotifier.notify_job_retry(job_retry)
         end
       end
 
@@ -31,7 +103,7 @@ module Barbeque
 
       def build_hako_oneshot_command(docker_image, command, envs)
         [
-          'bundle', 'exec', 'hako', 'oneshot', '--tag', docker_image.tag,
+          'bundle', 'exec', 'hako', 'oneshot', '--no-wait', '--tag', docker_image.tag,
           *env_options(envs), File.join(@yaml_dir, "#{docker_image.repository}.yml"), '--', *command,
         ]
       end
@@ -39,6 +111,41 @@ module Barbeque
       def env_options(envs)
         envs.map do |key, value|
           "--env=#{key}=#{value}"
+        end
+      end
+
+      def s3_key_for_stopped_result(hako_task)
+        "#{@s3_prefix}/#{hako_task.task_arn}/stopped.json"
+      end
+
+      def s3_client
+        @s3_client ||= Aws::S3::Client.new(region: @s3_region)
+      end
+
+      def get_stopped_result(hako_task)
+        object = s3_client.get_object(bucket: @s3_bucket, key: s3_key_for_stopped_result(hako_task))
+        JSON.parse(object.body.read)
+      rescue Aws::S3::Errors::NoSuchKey
+        nil
+      end
+
+      def extract_task_info(stdout)
+        last_line = stdout.lines.last
+        if last_line
+          begin
+            task_info = JSON.parse(last_line)
+            cluster = task_info['cluster']
+            task_arn = task_info['task_arn']
+            if cluster && task_arn
+              [cluster, task_arn]
+            else
+              raise HakoCommandError.new("Unable find cluster and task_arn in JSON: #{stdout}")
+            end
+          rescue JSON::ParserError => e
+            raise HakoCommandError.new("Unable parse the last line as JSON: #{stdout}")
+          end
+        else
+          raise HakoCommandError.new('stdout is empty')
         end
       end
     end

--- a/lib/barbeque/retry_poller.rb
+++ b/lib/barbeque/retry_poller.rb
@@ -1,0 +1,26 @@
+module Barbeque
+  class RetryPoller
+    def run
+      Barbeque::JobRetry.running.find_in_batches do |job_retries|
+        job_retries.shuffle.each do |job_retry|
+          job_retry.with_lock do
+            if job_retry.running?
+              poll(job_retry)
+            end
+          end
+        end
+      end
+      sleep 1
+    end
+
+    def stop
+    end
+
+    private
+
+    def poll(job_retry)
+      executor = Executor.create
+      executor.poll_retry(job_retry)
+    end
+  end
+end

--- a/lib/barbeque/retry_poller.rb
+++ b/lib/barbeque/retry_poller.rb
@@ -1,8 +1,15 @@
 module Barbeque
   class RetryPoller
+    def initialize
+      @stop_requested = false
+    end
+
     def run
       Barbeque::JobRetry.running.find_in_batches do |job_retries|
         job_retries.shuffle.each do |job_retry|
+          if @stop_requested
+            return
+          end
           job_retry.with_lock do
             if job_retry.running?
               poll(job_retry)
@@ -14,6 +21,7 @@ module Barbeque
     end
 
     def stop
+      @stop_requested = true
     end
 
     private

--- a/lib/barbeque/runner.rb
+++ b/lib/barbeque/runner.rb
@@ -5,6 +5,10 @@ require 'barbeque/message_handler'
 require 'barbeque/message_queue'
 
 module Barbeque
+  # Part of barbeque-worker.
+  # Runner dequeues a message from {MessageQueue} (Amazon SQS) and dispatches
+  # it to message handler.
+
   class Runner
     DEFAULT_QUEUE = 'default'
 

--- a/lib/barbeque/runner.rb
+++ b/lib/barbeque/runner.rb
@@ -1,0 +1,32 @@
+require 'barbeque/exception_handler'
+require 'barbeque/execution_log'
+require 'barbeque/message_handler'
+require 'barbeque/message_queue'
+
+module Barbeque
+  class Runner
+    DEFAULT_QUEUE = 'default'
+
+    def initialize(queue_name: ENV['BARBEQUE_QUEUE'] || DEFAULT_QUEUE)
+      @queue_name = queue_name
+    end
+
+    def run
+      message = message_queue.dequeue
+      return unless message
+
+      handler = MessageHandler.const_get(message.type, false)
+      handler.new(message: message, job_queue: message_queue.job_queue).run
+    end
+
+    def stop
+      message_queue.stop!
+    end
+
+    private
+
+    def message_queue
+      @message_queue ||= MessageQueue.new(@queue_name)
+    end
+  end
+end

--- a/lib/barbeque/runner.rb
+++ b/lib/barbeque/runner.rb
@@ -48,7 +48,7 @@ module Barbeque
         if current_num < max_num
           return
         end
-        interval = 10
+        interval = Barbeque.config.runner_wait_seconds
         Rails.logger.info("#{current_num} executions are running but maximum_concurrent_executions is configured to #{max_num}. Waiting #{interval} seconds...")
         sleep(interval)
       end

--- a/lib/barbeque/runner.rb
+++ b/lib/barbeque/runner.rb
@@ -48,7 +48,9 @@ module Barbeque
         if current_num < max_num
           return
         end
-        sleep 10
+        interval = 10
+        Rails.logger.info("#{current_num} executions are running but maximum_concurrent_executions is configured to #{max_num}. Waiting #{interval} seconds...")
+        sleep(interval)
       end
     end
   end

--- a/spec/barbeque/executor/docker_spec.rb
+++ b/spec/barbeque/executor/docker_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe Barbeque::Executor::Docker do
       let(:inspect_status) { double('Process::Status', success?: true) }
       let(:container_info) do
         {
-            'State' => {
-              'Status' => 'exited',
-              'FinishedAt' => '2017-07-11T09:17:32.013951633Z',
-              'ExitCode' => 0,
-            },
+          'State' => {
+            'Status' => 'exited',
+            'FinishedAt' => '2017-07-11T09:17:32.013951633Z',
+            'ExitCode' => 0,
+          },
         }
       end
       let(:stdout) { 'stdout' }

--- a/spec/barbeque/executor_spec.rb
+++ b/spec/barbeque/executor_spec.rb
@@ -24,7 +24,8 @@ describe Barbeque::Executor do
         expect(Barbeque::Executor::Hako).to receive(:new).with(
           hako_dir: '/home/k0kubun/hako_repo',
           hako_env: { 'ACCESS_TOKEN' => 'token' },
-          yaml_dir: '/yamls'
+          yaml_dir: '/yamls',
+          oneshot_notification_prefix: 's3://barbeque/task_statuses?region=ap-northeast-1',
         )
         Barbeque::Executor.create
       end

--- a/spec/barbeque/runner_spec.rb
+++ b/spec/barbeque/runner_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+require 'barbeque/runner'
+
+RSpec.describe Barbeque::Runner do
+  let(:runner) { described_class.new }
+  let(:message_body) do
+    JSON.dump(
+      'Type' => 'JobExecution',
+      'Application' => 'barbeque-spec',
+      'Job' => 'BarbequeSpecJob',
+      'Message' => { 'FOO' => 'BAR' },
+    )
+  end
+  let(:sqs_message) { Aws::SQS::Types::Message.new(body: message_body) }
+  let(:message) { Barbeque::Message.parse(sqs_message) }
+  let(:message_queue) { double('Barbeque::MessageQueue', job_queue: 'default') }
+  let(:handler) { double('Barbeque::MessageHandler') }
+
+  before do
+    allow(runner).to receive(:message_queue).and_return(message_queue)
+    allow(message_queue).to receive(:dequeue).and_return(message)
+  end
+
+  describe '#run' do
+    context 'with JobExecution message' do
+      it 'runs JobExecution message handler' do
+        expect(Barbeque::MessageHandler::JobExecution).to receive(:new).and_return(handler)
+        expect(handler).to receive(:run)
+        runner.run
+      end
+
+      context 'with maximum_concurrent_executions' do
+        before do
+          allow(Barbeque.config).to receive(:maximum_concurrent_executions).and_return(3)
+        end
+
+        it 'runs JobExecution message handler without sleep' do
+          expect(runner).to_not receive(:sleep)
+          expect(Barbeque::MessageHandler::JobExecution).to receive(:new).and_return(handler)
+          expect(handler).to receive(:run)
+          runner.run
+        end
+
+        context "when there's many working executions" do
+          before do
+            2.times do
+              FactoryGirl.create(:job_execution, status: :running)
+            end
+            FactoryGirl.create(:job_execution, status: :retried)
+          end
+
+          it 'waits' do
+            expect(runner).to receive(:sleep) {
+              # One execution finishes during sleep
+              Barbeque::JobExecution.first.update!(status: :success)
+            }
+            expect(Barbeque::MessageHandler::JobExecution).to receive(:new).and_return(handler)
+            expect(handler).to receive(:run)
+            runner.run
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/barbeque/runner_spec.rb
+++ b/spec/barbeque/runner_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Barbeque::Runner do
           end
 
           it 'waits' do
-            expect(runner).to receive(:sleep) {
+            expect(runner).to receive(:sleep) { |interval|
+              expect(interval).to eq(10)
               # One execution finishes during sleep
               Barbeque::JobExecution.first.update!(status: :success)
             }

--- a/spec/dummy/config/barbeque.hako.yml
+++ b/spec/dummy/config/barbeque.hako.yml
@@ -5,6 +5,7 @@ default: &default
     hako_env:
       ACCESS_TOKEN: token
     yaml_dir: /yamls
+    oneshot_notification_prefix: s3://barbeque/task_statuses?region=ap-northeast-1
 
 development:
   <<: *default

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170420030157) do
+ActiveRecord::Schema.define(version: 20170712075449) do
 
   create_table "barbeque_apps", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
     t.string   "name",                       null: false
@@ -19,6 +19,23 @@ ActiveRecord::Schema.define(version: 20170420030157) do
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
     t.index ["name"], name: "index_barbeque_apps_on_name", unique: true, using: :btree
+  end
+
+  create_table "barbeque_docker_containers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+    t.string   "message_id",   null: false
+    t.string   "container_id", null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["message_id"], name: "index_barbeque_docker_containers_on_message_id", unique: true, using: :btree
+  end
+
+  create_table "barbeque_ecs_hako_tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+    t.string   "message_id", null: false
+    t.string   "cluster",    null: false
+    t.string   "task_arn",   null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["message_id"], name: "index_barbeque_ecs_hako_tasks_on_message_id", unique: true, using: :btree
   end
 
   create_table "barbeque_job_definitions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|


### PR DESCRIPTION
This patch implements #32 feature. Please read description and discussion in #32 to understand the overall design.

Now `rake barbeque:worker` launches three types of process.

- Runner: receives message from SQS queue, starts job execution and stores its identifier to the database
  - In Executor::Docker, the identifier is container id
  - In Executor::Hako, the identifier is ECS cluster and task ARN
- ExecutionPoller: polls execution status and reflect it to the database
  - In Executor::Docker, uses `docker inspect` command
  - In Executor::Hako, uses S3 task notification JSON
- RetryPoller: polls retry status and reflect it to the database
  - Same with ExecutionPoller

---

@cookpad/dev-infra @k0kubun please review 🙏 