### PR TITLE
Delete message after saving message body to S3

### DIFF
--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -6,19 +6,21 @@ module Barbeque
   module MessageHandler
     class JobExecution
       # @param [Barbeque::Message::JobExecution] message
-      # @param [Barbeque::JobQueue] job_queue
-      def initialize(message:, job_queue:)
+      # @param [Barbeque::MessageQueue] message_queue
+      def initialize(message:, message_queue:)
         @message = message
-        @job_queue = job_queue
+        @message_queue = message_queue
       end
 
       def run
         begin
-          job_execution = Barbeque::JobExecution.create(message_id: @message.id, job_definition: job_definition, job_queue: @job_queue)
+          job_execution = Barbeque::JobExecution.create(message_id: @message.id, job_definition: job_definition, job_queue: @message_queue.job_queue)
         rescue ActiveRecord::RecordNotUnique => e
+          @message_queue.delete_message(@message)
           raise DuplicatedExecution.new(e.message)
         end
-        Barbeque::ExecutionLog.save_message(job_execution, @message)  # TODO: Should be saved earlier
+        Barbeque::ExecutionLog.save_message(job_execution, @message)
+        @message_queue.delete_message(@message)
 
         begin
           Executor.create.start_execution(job_execution, job_envs)
@@ -37,7 +39,7 @@ module Barbeque
           'BARBEQUE_JOB'         => @message.job,
           'BARBEQUE_MESSAGE'     => @message.body.to_json,
           'BARBEQUE_MESSAGE_ID'  => @message.id,
-          'BARBEQUE_QUEUE_NAME'  => @job_queue.name,
+          'BARBEQUE_QUEUE_NAME'  => @message_queue.job_queue.name,
           'BARBEQUE_RETRY_COUNT' => '0',
         }
       end

--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -16,7 +16,6 @@ module Barbeque
         begin
           job_execution = Barbeque::JobExecution.create(message_id: @message.id, job_definition: job_definition, job_queue: @message_queue.job_queue)
         rescue ActiveRecord::RecordNotUnique => e
-          @message_queue.delete_message(@message)
           raise DuplicatedExecution.new(e.message)
         end
         Barbeque::ExecutionLog.save_message(job_execution, @message)

--- a/lib/barbeque/message_handler/job_retry.rb
+++ b/lib/barbeque/message_handler/job_retry.rb
@@ -18,7 +18,6 @@ module Barbeque
         begin
           job_retry = Barbeque::JobRetry.create(message_id: @message.id, job_execution: job_execution)
         rescue ActiveRecord::RecordNotUnique => e
-          @message_queue.delete_message(@message)
           raise DuplicatedExecution.new(e.message)
         end
         @message_queue.delete_message(@message)

--- a/lib/barbeque/message_handler/notification.rb
+++ b/lib/barbeque/message_handler/notification.rb
@@ -4,12 +4,12 @@ module Barbeque
   module MessageHandler
     class Notification < JobExecution
       # @param [Barbeque::Message::Notification] message
-      # @param [Barbeque::JobQueue] job_queue
-      def initialize(message:, job_queue:)
+      # @param [Barbeque::MessageQueue] message_queue
+      def initialize(message:, message_queue:)
         @message = message
-        @job_queue = job_queue
+        @message_queue = message_queue
 
-        subscription = SNSSubscription.find_by!(topic_arn: @message.topic_arn, job_queue_id: @job_queue.id)
+        subscription = SNSSubscription.find_by!(topic_arn: @message.topic_arn, job_queue_id: @message_queue.job_queue.id)
         @message.set_params_from_subscription(subscription)
       end
     end

--- a/lib/barbeque/message_queue.rb
+++ b/lib/barbeque/message_queue.rb
@@ -4,9 +4,6 @@ require 'barbeque/message'
 
 module Barbeque
   class MessageQueue
-    class ExtendVisibilityError < StandardError
-    end
-
     attr_reader :job_queue
 
     def initialize(queue_name)
@@ -55,17 +52,6 @@ module Barbeque
       if result.messages[0]
         Barbeque::Message.parse(result.messages[0])
       end
-    end
-
-    def extend_visibility_timeout(messages)
-      resp = client.change_message_visibility_batch(
-        queue_url: @job_queue.queue_url,
-        entries: messages.map { |message| { id: message.message_id, receipt_handle: message.receipt_handle, visibility_timeout: 60 } },
-      )
-      unless resp.failed.empty?
-        raise "Failed to extend visibility timeout: #{resp.failed.map(&:inspect)}"
-      end
-      nil
     end
 
     def client

--- a/lib/barbeque/runner.rb
+++ b/lib/barbeque/runner.rb
@@ -23,7 +23,7 @@ module Barbeque
       return unless message
 
       handler = MessageHandler.const_get(message.type, false)
-      handler.new(message: message, job_queue: message_queue.job_queue).run
+      handler.new(message: message, message_queue: message_queue).run
     end
 
     def stop

--- a/spec/barbeque/message_handler/job_execution_spec.rb
+++ b/spec/barbeque/message_handler/job_execution_spec.rb
@@ -3,9 +3,10 @@ require 'barbeque/worker'
 
 describe Barbeque::MessageHandler::JobExecution do
   describe '#run' do
-    let(:handler) { Barbeque::MessageHandler::JobExecution.new(message: message, job_queue: job_queue) }
+    let(:handler) { Barbeque::MessageHandler::JobExecution.new(message: message, message_queue: message_queue) }
     let(:job_definition) { create(:job_definition) }
     let(:job_queue)      { create(:job_queue) }
+    let(:message_queue) { Barbeque::MessageQueue.new(job_queue.name) }
     let(:message) do
       Barbeque::Message::JobExecution.new(
         Aws::SQS::Types::Message.new(message_id: SecureRandom.uuid, receipt_handle: 'dummy receipt handle'),
@@ -24,6 +25,7 @@ describe Barbeque::MessageHandler::JobExecution do
       allow(Barbeque::Executor::Docker).to receive(:new).with({}).and_return(executor)
       allow(Barbeque::ExecutionLog).to receive(:save_message)
       allow(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr)
+      expect(message_queue).to receive(:delete_message).with(message)
     end
 
     around do |example|

--- a/spec/barbeque/message_handler/job_retry_spec.rb
+++ b/spec/barbeque/message_handler/job_retry_spec.rb
@@ -3,8 +3,9 @@ require 'barbeque/worker'
 
 describe Barbeque::MessageHandler::JobRetry do
   describe '#run' do
-    let(:handler) { Barbeque::MessageHandler::JobRetry.new(message: message, job_queue: job_queue) }
+    let(:handler) { Barbeque::MessageHandler::JobRetry.new(message: message, message_queue: message_queue) }
     let(:job_queue) { create(:job_queue) }
+    let(:message_queue) { Barbeque::MessageQueue.new(job_queue.name) }
     let(:job_definition) { create(:job_definition) }
     let(:job_execution) { create(:job_execution, status: :failed, job_definition: job_definition, job_queue: job_queue) }
     let(:message) do
@@ -22,6 +23,7 @@ describe Barbeque::MessageHandler::JobRetry do
       allow(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr)
       allow(Barbeque::ExecutionLog).to receive(:load).with(execution: job_execution).and_return({ 'message' => message_body })
       allow(Barbeque::Executor::Docker).to receive(:new).with({}).and_return(executor)
+      expect(message_queue).to receive(:delete_message).with(message)
     end
 
     around do |example|

--- a/spec/barbeque/message_handler/notification_spec.rb
+++ b/spec/barbeque/message_handler/notification_spec.rb
@@ -13,9 +13,10 @@ describe Barbeque::MessageHandler::Notification do
         }
       )
     end
+    let(:message_queue) { Barbeque::MessageQueue.new(sns_subscription.job_queue.name) }
 
     it 'creates Notification message handler from Notification message' do
-      handler = Barbeque::MessageHandler::Notification.new(message: message, job_queue: sns_subscription.job_queue)
+      handler = Barbeque::MessageHandler::Notification.new(message: message, message_queue: message_queue)
       expect(handler).to be_a(Barbeque::MessageHandler::JobExecution)
     end
   end

--- a/spec/barbeque/worker_spec.rb
+++ b/spec/barbeque/worker_spec.rb
@@ -26,7 +26,7 @@ describe Barbeque::Worker do
 
   before do
     allow(Barbeque::MessageQueue).to receive(:new).and_return(message_queue)
-    allow(Barbeque::MessageHandler::JobExecution).to receive(:new).with(message: message, job_queue: job_queue).and_return(job)
+    allow(Barbeque::MessageHandler::JobExecution).to receive(:new).with(message: message, message_queue: message_queue).and_return(job)
   end
 
   describe '#execute_command' do
@@ -80,12 +80,12 @@ describe Barbeque::Worker do
             retry_message_id: job_execution.message_id,
           )
         end
-        let(:execution_retry) { Barbeque::MessageHandler::JobRetry.new(message: message, job_queue: job_queue) }
+        let(:execution_retry) { Barbeque::MessageHandler::JobRetry.new(message: message, message_queue: message_queue) }
 
         before do
           create(:job_retry, job_execution: job_execution, message_id: retry_message_id)
           allow(Barbeque::MessageHandler::JobRetry).to receive(:new).
-            with(message: message, job_queue: job_queue).and_return(execution_retry)
+            with(message: message, message_queue: message_queue).and_return(execution_retry)
           allow(execution_retry).to receive(:run).and_return([stdout, stderr, status])
         end
 


### PR DESCRIPTION
SQS messages should be available until recoverability is ensured.
We have to care about the visibility timeout.

1. Receive a message from MessageQueue
2. Dispatch the message to MessageHandler::XXX
3. Create a record for execution
4. Save the message body to S3 (if necessary)
5. Delete the message
6. Start execution

I think it takes less than 30s (default visibility timeout) between 1
and 5.

----

#39 
@cookpad/dev-infra @k0kubun please review