### PR TITLE
Add message context to exception handler

### DIFF
--- a/lib/barbeque/execution_poller.rb
+++ b/lib/barbeque/execution_poller.rb
@@ -1,3 +1,5 @@
+require 'barbeque/exception_handler'
+
 module Barbeque
   class ExecutionPoller
     def initialize
@@ -27,6 +29,7 @@ module Barbeque
     private
 
     def poll(job_execution)
+      Barbeque::ExceptionHandler.set_message_context(job_execution.message_id, nil)
       executor = Executor.create
       executor.poll_execution(job_execution)
     end

--- a/lib/barbeque/retry_poller.rb
+++ b/lib/barbeque/retry_poller.rb
@@ -27,6 +27,7 @@ module Barbeque
     private
 
     def poll(job_retry)
+      Barbeque::ExceptionHandler.set_message_context(job_retry.message_id, nil)
       executor = Executor.create
       executor.poll_retry(job_retry)
     end

--- a/lib/barbeque/runner.rb
+++ b/lib/barbeque/runner.rb
@@ -22,6 +22,7 @@ module Barbeque
       message = message_queue.dequeue
       return unless message
 
+      Barbeque::ExceptionHandler.set_message_context(message.id, message.type)
       handler = MessageHandler.const_get(message.type, false)
       handler.new(message: message, message_queue: message_queue).run
     end

--- a/lib/barbeque/worker.rb
+++ b/lib/barbeque/worker.rb
@@ -1,3 +1,4 @@
+require 'barbeque/exception_handler'
 require 'barbeque/execution_poller'
 require 'barbeque/retry_poller'
 require 'barbeque/runner'
@@ -50,6 +51,7 @@ module Barbeque
         rescue => e
           Barbeque::ExceptionHandler.handle_exception(e)
         end
+        Barbeque::ExceptionHandler.clear_context
       end
     end
 

--- a/spec/barbeque/exception_handler_spec.rb
+++ b/spec/barbeque/exception_handler_spec.rb
@@ -15,7 +15,7 @@ describe Barbeque::ExceptionHandler do
     end
 
     it 'handles exception with configured handler' do
-      expect(Barbeque::ExceptionHandler::RailsLogger).to receive(:handle_exception).with(exception)
+      expect_any_instance_of(Barbeque::ExceptionHandler::RailsLogger).to receive(:handle_exception).with(exception)
       Barbeque::ExceptionHandler.handle_exception(exception)
     end
   end


### PR DESCRIPTION
I'd like to know which message is being processed while debugging
exceptions.

@cookpad/dev-infra @k0kubun what do you think?