### PR TITLE
Do not create execution record when sqs:DeleteMessage fails

### DIFF
--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -14,7 +14,6 @@ module Barbeque
 
       def run
         job_execution = create_job_execution
-        @message_queue.delete_message(@message)
 
         begin
           Executor.create.start_execution(job_execution, job_envs)
@@ -49,6 +48,7 @@ module Barbeque
         Barbeque::JobExecution.transaction do
           Barbeque::JobExecution.create(message_id: @message.id, job_definition: job_definition, job_queue: @message_queue.job_queue).tap do |job_execution|
             Barbeque::ExecutionLog.save_message(job_execution, @message)
+            @message_queue.delete_message(@message)
           end
         end
       rescue ActiveRecord::RecordNotUnique => e

--- a/spec/barbeque/message_handler/job_execution_spec.rb
+++ b/spec/barbeque/message_handler/job_execution_spec.rb
@@ -78,6 +78,17 @@ describe Barbeque::MessageHandler::JobExecution do
       end
     end
 
+    context 'when sqs:DeleteMessage returns error' do
+      before do
+        expect(message_queue).to receive(:delete_message).with(message).and_raise(Aws::SQS::Errors::InternalError.new(nil, 'We encountered an internal error. Please try again.'))
+      end
+
+      it "doesn't create job_execution record" do
+        expect { handler.run }.to raise_error(Aws::SQS::Errors::InternalError)
+        expect(Barbeque::JobExecution.count).to eq(0)
+      end
+    end
+
     context 'when unhandled exception is raised' do
       let(:exception) { Class.new(StandardError) }
 

--- a/spec/barbeque/message_handler/job_retry_spec.rb
+++ b/spec/barbeque/message_handler/job_retry_spec.rb
@@ -77,6 +77,17 @@ describe Barbeque::MessageHandler::JobRetry do
       end
     end
 
+    context 'when sqs:DeleteMessage returns error' do
+      before do
+        expect(message_queue).to receive(:delete_message).with(message).and_raise(Aws::SQS::Errors::InternalError.new(nil, 'We encountered an internal error. Please try again.'))
+      end
+
+      it "doesn't create job_retries record" do
+        expect { handler.run }.to raise_error(Aws::SQS::Errors::InternalError)
+        expect(Barbeque::JobRetry.count).to eq(0)
+      end
+    end
+
     context 'when unhandled exception is raised' do
       let(:exception) { Class.new(StandardError) }
 


### PR DESCRIPTION
@cookpad/dev-infra please review