### PR TITLE
Redirect /job_executions/:id to /job_executions/:message_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.0.0 (xxxx-xx-xx)
+### Incompatibilities
+- Job execution URL was changed from `/job_executions/:id` to `/job_executions/:message_id`
+  - Barbeque v1.0 links are redirected to v2.0 links
+
 ## v1.4.1 (2017-09-05)
 ### Bug fixes
 - Do not create execution record when sqs:DeleteMessage returns error

--- a/app/controllers/barbeque/job_executions_controller.rb
+++ b/app/controllers/barbeque/job_executions_controller.rb
@@ -1,21 +1,21 @@
 class Barbeque::JobExecutionsController < Barbeque::ApplicationController
-  MESSAGE_ID_REGEXP = /\A[0-9a-f-]+\z/
+  ID_REGEXP = /\A[0-9]+\z/
 
   def show
-    if MESSAGE_ID_REGEXP === params[:id]
-      job_execution = Barbeque::JobExecution.find_by(message_id: params[:id])
+    if ID_REGEXP === params[:message_id]
+      job_execution = Barbeque::JobExecution.find(params[:message_id])
       if job_execution
         redirect_to(job_execution)
         return
       end
     end
-    @job_execution = Barbeque::JobExecution.find(params[:id])
+    @job_execution = Barbeque::JobExecution.find_by!(message_id: params[:message_id])
     @log = @job_execution.execution_log
     @job_retries = @job_execution.job_retries.order(id: :desc)
   end
 
   def retry
-    @job_execution = Barbeque::JobExecution.find(params[:job_execution_id])
+    @job_execution = Barbeque::JobExecution.find_by!(message_id: params[:job_execution_message_id])
     raise ActionController::BadRequest unless @job_execution.retryable?
 
     result = Barbeque::MessageRetryingService.new(message_id: @job_execution.message_id).run

--- a/app/controllers/barbeque/job_executions_controller.rb
+++ b/app/controllers/barbeque/job_executions_controller.rb
@@ -1,5 +1,14 @@
 class Barbeque::JobExecutionsController < Barbeque::ApplicationController
+  MESSAGE_ID_REGEXP = /\A[0-9a-f-]+\z/
+
   def show
+    if MESSAGE_ID_REGEXP === params[:id]
+      job_execution = Barbeque::JobExecution.find_by(message_id: params[:id])
+      if job_execution
+        redirect_to(job_execution)
+        return
+      end
+    end
     @job_execution = Barbeque::JobExecution.find(params[:id])
     @log = @job_execution.execution_log
     @job_retries = @job_execution.job_retries.order(id: :desc)

--- a/app/controllers/barbeque/job_retries_controller.rb
+++ b/app/controllers/barbeque/job_retries_controller.rb
@@ -1,6 +1,6 @@
 class Barbeque::JobRetriesController < Barbeque::ApplicationController
   def show
-    @job_execution = Barbeque::JobExecution.find(params[:job_execution_id])
+    @job_execution = Barbeque::JobExecution.find_by!(message_id: params[:job_execution_message_id])
     @execution_log = @job_execution.execution_log
 
     @job_retry = Barbeque::JobRetry.find(params[:id])

--- a/app/models/barbeque/job_execution.rb
+++ b/app/models/barbeque/job_execution.rb
@@ -24,4 +24,8 @@ class Barbeque::JobExecution < Barbeque::ApplicationRecord
   def retryable?
     failed? || error?
   end
+
+  def to_param
+    message_id
+  end
 end

--- a/app/views/barbeque/job_executions/show.html.haml
+++ b/app/views/barbeque/job_executions/show.html.haml
@@ -5,7 +5,7 @@
     %li= link_to('Home', root_path)
     %li= link_to(job_definition.app.name, app_path(job_definition.app.id))
     %li= link_to(job_definition.job, job_definition_path(job_definition.id))
-    %li.active ##{@job_execution.id}
+    %li.active ##{@job_execution.message_id}
 
 .row
   .col-sm-7

--- a/app/views/barbeque/job_retries/show.html.haml
+++ b/app/views/barbeque/job_retries/show.html.haml
@@ -6,7 +6,7 @@
     %li= link_to('Home', root_path)
     %li= link_to(job_definition.app.name, app_path(job_definition.app.id))
     %li= link_to(job_definition.job, job_definition_path(job_definition.id))
-    %li= link_to("##{job_execution.id}", job_execution_path(job_execution.id))
+    %li= link_to("##{job_execution.message_id}", job_execution_path(job_execution))
     %li.active ##{@job_retry.id}
 
 .row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Barbeque::Engine.routes.draw do
     get :execution_stats
   end
 
-  resources :job_executions, only: :show do
+  resources :job_executions, only: :show, param: :message_id do
     post :retry
 
     resources :job_retries, only: :show

--- a/spec/controllers/barbeque/job_executions_controller_spec.rb
+++ b/spec/controllers/barbeque/job_executions_controller_spec.rb
@@ -27,6 +27,13 @@ describe Barbeque::JobExecutionsController do
       get :show, params: { id: job_execution.id }
       expect(assigns(:log)).to eq({ 'message' => message, 'stdout' => stdout, 'stderr' => stderr })
     end
+
+    context 'with message_id' do
+      it 'redirects to job execution' do
+        get :show, params: { id: job_execution.message_id }
+        expect(response).to redirect_to(job_execution_path(job_execution.id))
+      end
+    end
   end
 
   describe '#retry' do

--- a/spec/controllers/barbeque/job_executions_controller_spec.rb
+++ b/spec/controllers/barbeque/job_executions_controller_spec.rb
@@ -19,19 +19,19 @@ describe Barbeque::JobExecutionsController do
     end
 
     it 'shows job definition' do
-      get :show, params: { id: job_execution.id }
+      get :show, params: { message_id: job_execution.message_id }
       expect(assigns(:job_execution)).to eq(job_execution)
     end
 
     it 'shows message, stdout, stderr in S3' do
-      get :show, params: { id: job_execution.id }
+      get :show, params: { message_id: job_execution.message_id }
       expect(assigns(:log)).to eq({ 'message' => message, 'stdout' => stdout, 'stderr' => stderr })
     end
 
-    context 'with message_id' do
+    context 'with id' do
       it 'redirects to job execution' do
-        get :show, params: { id: job_execution.message_id }
-        expect(response).to redirect_to(job_execution_path(job_execution.id))
+        get :show, params: { message_id: job_execution.id }
+        expect(response).to redirect_to(job_execution_path(job_execution))
       end
     end
   end
@@ -53,7 +53,7 @@ describe Barbeque::JobExecutionsController do
       ).and_return(retrying_service)
 
       expect {
-        post :retry, params: { job_execution_id: job_execution.id }
+        post :retry, params: { job_execution_message_id: job_execution.message_id }
       }.to change {
         job_execution.reload.status
       }.from('failed').to('retried')
@@ -64,7 +64,7 @@ describe Barbeque::JobExecutionsController do
 
       it 'does not retry' do
         expect {
-          post :retry, params: { job_execution_id: job_execution.id }
+          post :retry, params: { job_execution_message_id: job_execution.message_id }
         }.to raise_error(ActionController::BadRequest)
       end
     end
@@ -78,7 +78,7 @@ describe Barbeque::JobExecutionsController do
         ).and_return(retrying_service)
 
         expect {
-          post :retry, params: { job_execution_id: job_execution.id }
+          post :retry, params: { job_execution_message_id: job_execution.message_id }
         }.to change {
           job_execution.reload.status
         }.from('error').to('retried')

--- a/spec/controllers/barbeque/job_retries_controller_spec.rb
+++ b/spec/controllers/barbeque/job_retries_controller_spec.rb
@@ -23,12 +23,12 @@ describe Barbeque::JobRetriesController do
     end
 
     it 'shows job retry' do
-      get :show, params: { job_execution_id: job_execution.id, id: job_retry.id }
+      get :show, params: { job_execution_message_id: job_execution.message_id, id: job_retry.id }
       expect(assigns(:job_retry)).to eq(job_retry)
     end
 
     it 'shows message, stdout, stderr in S3' do
-      get :show, params: { job_execution_id: job_execution.id, id: job_retry.id }
+      get :show, params: { job_execution_message_id: job_execution.message_id, id: job_retry.id }
       expect(assigns(:execution_log)).to eq(execution_log)
       expect(assigns(:retry_log)).to eq(retry_log)
     end

--- a/spec/requests/api/job_executions_spec.rb
+++ b/spec/requests/api/job_executions_spec.rb
@@ -25,7 +25,7 @@ describe 'job_executions' do
             'message_id' => job_execution.message_id,
             'status'     => status,
             'id'         => job_execution.id,
-            'html_url'   => "http://www.example.com/job_executions/#{job_execution.id}",
+            'html_url'   => "http://www.example.com/job_executions/#{job_execution.message_id}",
           )
         end
       end


### PR DESCRIPTION
Since job_executions has [unique message_id](https://github.com/cookpad/barbeque/blob/v1.4.1/spec/dummy/db/schema.rb#L60) and enqueueing service knows the message_id, redirecting message_id to id seems useful to me.


@cookpad/dev-infra What do you think?