### PR TITLE
Redirect /job_executions/:id/job_retries/:id to /job_executions/:message_id/job_retries/:id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Incompatibilities
 - Job execution URL was changed from `/job_executions/:id` to `/job_executions/:message_id`
   - Barbeque v1.0 links are redirected to v2.0 links
+  - Job retry URL `/job_executions/:id/job_retries/:id` is also redirected to `/job_executions/:message_id/job_retries/:id`
 
 ## v1.4.1 (2017-09-05)
 ### Bug fixes

--- a/app/controllers/barbeque/job_retries_controller.rb
+++ b/app/controllers/barbeque/job_retries_controller.rb
@@ -1,9 +1,13 @@
 class Barbeque::JobRetriesController < Barbeque::ApplicationController
   def show
-    @job_execution = Barbeque::JobExecution.find_by!(message_id: params[:job_execution_message_id])
-    @execution_log = @job_execution.execution_log
-
     @job_retry = Barbeque::JobRetry.find(params[:id])
+    @job_execution = @job_retry.job_execution
+
+    if params[:job_execution_message_id] != @job_execution.message_id
+      redirect_to([@job_execution, @job_retry])
+    end
+
+    @execution_log = @job_execution.execution_log
     @retry_log = @job_retry.execution_log
   end
 end

--- a/spec/controllers/barbeque/job_retries_controller_spec.rb
+++ b/spec/controllers/barbeque/job_retries_controller_spec.rb
@@ -32,5 +32,12 @@ describe Barbeque::JobRetriesController do
       expect(assigns(:execution_log)).to eq(execution_log)
       expect(assigns(:retry_log)).to eq(retry_log)
     end
+
+    context 'when job_execution id is given' do
+      it "redirects to job_retry with job_execution's message id" do
+        get :show, params: { job_execution_message_id: job_execution.id, id: job_retry.id }
+        expect(response).to redirect_to(job_execution_job_retry_path(job_execution, job_retry))
+      end
+    end
   end
 end


### PR DESCRIPTION
This follows up #56 .
Add one more redirection for Barbeque v2.0.

@cookpad/dev-infra @k0kubun please review