### PR TITLE
Support Hako definitions written in Jsonnet

### DIFF
--- a/spec/barbeque/executor/hako_spec.rb
+++ b/spec/barbeque/executor/hako_spec.rb
@@ -9,7 +9,7 @@ describe Barbeque::Executor::Hako do
     described_class.new(
       hako_dir: hako_directory,
       hako_env: hako_env,
-      yaml_dir: '/yamls',
+      definition_dir: '/yamls',
       oneshot_notification_prefix: 's3://barbeque/task_statuses?region=ap-northeast-1',
     )
   end

--- a/spec/barbeque/executor/hako_spec.rb
+++ b/spec/barbeque/executor/hako_spec.rb
@@ -52,6 +52,8 @@ describe Barbeque::Executor::Hako do
       let(:stderr) { '' }
 
       before do
+        allow(File).to receive(:readable?).with("/yamls/#{app_name}.jsonnet").and_return(false)
+        allow(File).to receive(:readable?).with("/yamls/#{app_name}.yml").and_return(true)
         expect(Open3).to receive(:capture3).with(
           hako_env,
           'bundle', 'exec', 'hako', 'oneshot', '--no-wait', '--tag', 'latest',
@@ -207,6 +209,8 @@ describe Barbeque::Executor::Hako do
 
     describe '#start_retry' do
       before do
+        allow(File).to receive(:readable?).with("/yamls/#{app_name}.jsonnet").and_return(false)
+        allow(File).to receive(:readable?).with("/yamls/#{app_name}.yml").and_return(true)
         expect(Open3).to receive(:capture3).with(
           hako_env,
           'bundle', 'exec', 'hako', 'oneshot', '--no-wait', '--tag', 'latest',


### PR DESCRIPTION
Hako started supporting Jsonnet as an alternative format of application definitions.
https://github.com/eagletmt/hako/pull/41
This pull-request adds support for Hako definitions written in Jsonnet.

Note that `yaml_dir` option is renamed to `definition_dir` because Hako definitions could be written both in YAML and in Jsonnet now.

@cookpad/dev-infra please review