### PR TITLE
Poll job executions and job retries only of the specified queue

### DIFF
--- a/lib/barbeque/execution_poller.rb
+++ b/lib/barbeque/execution_poller.rb
@@ -1,13 +1,15 @@
 require 'barbeque/exception_handler'
+require 'barbeque/executor'
 
 module Barbeque
   class ExecutionPoller
-    def initialize
+    def initialize(job_queue)
+      @job_queue      = job_queue
       @stop_requested = false
     end
 
     def run
-      Barbeque::JobExecution.running.find_in_batches do |job_executions|
+      @job_queue.job_executions.running.find_in_batches do |job_executions|
         job_executions.shuffle.each do |job_execution|
           if @stop_requested
             return

--- a/lib/barbeque/retry_poller.rb
+++ b/lib/barbeque/retry_poller.rb
@@ -12,7 +12,7 @@ module Barbeque
       Barbeque::JobRetry
         .joins(:job_execution)
         .running
-        .where("#{Barbeque::JobExecution.table_name}.job_queue_id = #{@job_queue.id}")
+        .merge(Barbeque::JobExecution.where(job_queue: @job_queue))
         .find_in_batches do |job_retries|
         job_retries.shuffle.each do |job_retry|
           if @stop_requested

--- a/lib/barbeque/runner.rb
+++ b/lib/barbeque/runner.rb
@@ -10,10 +10,8 @@ module Barbeque
   # it to message handler.
 
   class Runner
-    DEFAULT_QUEUE = 'default'
-
-    def initialize(queue_name: ENV['BARBEQUE_QUEUE'] || DEFAULT_QUEUE)
-      @job_queue = Barbeque::JobQueue.find_by!(name: queue_name)
+    def initialize(job_queue)
+      @job_queue = job_queue
     end
 
     def run

--- a/lib/barbeque/worker.rb
+++ b/lib/barbeque/worker.rb
@@ -6,6 +6,8 @@ require 'serverengine'
 
 module Barbeque
   module Worker
+    DEFAULT_QUEUE = ENV['BARBEQUE_DEFAULT_QUEUE'] || 'default'
+
     class UnexpectedMessageType < StandardError; end
 
     def self.run(
@@ -32,14 +34,17 @@ module Barbeque
     end
 
     def initialize
+      queue_name = ENV['BARBEQUE_QUEUE'] || DEFAULT_QUEUE
+      queue      = Barbeque::JobQueue.find_by!(name: queue_name)
+
       @command =
         case worker_id
         when 0
-          ExecutionPoller.new
+          ExecutionPoller.new(queue)
         when 1
-          RetryPoller.new
+          RetryPoller.new(queue)
         else
-          Runner.new
+          Runner.new(queue)
         end
     end
 

--- a/spec/barbeque/execution_poller_spec.rb
+++ b/spec/barbeque/execution_poller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+require 'barbeque/execution_poller'
+
+RSpec.describe Barbeque::ExecutionPoller do
+  let(:job_queue) { create(:job_queue) }
+  let(:execution_poller) { described_class.new(job_queue) }
+  let(:executor) { double('Barbeque::Executor::Docker') }
+
+  before do
+    allow(Barbeque::Executor::Docker).to receive(:new).with({}).and_return(executor)
+  end
+
+  describe '#run' do
+    context 'when there is a running job execution' do
+      let(:job_execution) { create(:job_execution, status: :running, job_queue: job_queue) }
+
+      it 'polls the job execution' do
+        expect(executor).to receive(:poll_execution).with(job_execution)
+        execution_poller.run
+      end
+    end
+  end
+end

--- a/spec/barbeque/retry_poller_spec.rb
+++ b/spec/barbeque/retry_poller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'barbeque/retry_poller'
+
+RSpec.describe Barbeque::RetryPoller do
+  let(:job_queue) { create(:job_queue) }
+  let(:retry_poller) { described_class.new(job_queue) }
+  let(:executor) { double('Barbeque::Executor::Docker') }
+
+  before do
+    allow(Barbeque::Executor::Docker).to receive(:new).with({}).and_return(executor)
+  end
+
+  describe '#run' do
+    context 'when there is a running job retry' do
+      let(:job_execution) { create(:job_execution, status: :retried, job_queue: job_queue) }
+      let(:job_retry) { create(:job_retry, job_execution: job_execution, status: :running) }
+
+      it 'polls the job retry' do
+        expect(executor).to receive(:poll_retry).with(job_retry)
+        retry_poller.run
+      end
+    end
+  end
+end

--- a/spec/barbeque/runner_spec.rb
+++ b/spec/barbeque/runner_spec.rb
@@ -3,7 +3,7 @@ require 'barbeque/runner'
 
 RSpec.describe Barbeque::Runner do
   let(:job_queue) { create(:job_queue) }
-  let(:runner) { described_class.new(queue_name: job_queue.name) }
+  let(:runner) { described_class.new(job_queue) }
   let(:message_body) do
     JSON.dump(
       'Type' => 'JobExecution',

--- a/spec/factories/job_retry.rb
+++ b/spec/factories/job_retry.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :job_retry, class: Barbeque::JobRetry do
     message_id { SecureRandom.uuid }
-    status 1
+    status :success
     finished_at "2016-05-16 13:17:10"
     job_execution
   end


### PR DESCRIPTION
I think pollers should handle executions and retries of messages enqueued into the specified queue (or the default queue) only.

This PR depends on #61. The diff from that PR could be found at:

https://github.com/kaorimatz/barbeque/compare/limit-concurrent-executions-per-job-queue...kaorimatz:poll-job_executions-and-job_retries-only-of-the-specified-queue