### PR TITLE
Fix wrong aggregation query in /monitors

### DIFF
--- a/app/controllers/barbeque/monitors_controller.rb
+++ b/app/controllers/barbeque/monitors_controller.rb
@@ -30,13 +30,14 @@ SQL
 
     jobs = {}
     rows.each do |row|
+      job_id = row.fetch('job_id')
       job = {
         app_id: row.fetch('app_id'),
         app_name: row.fetch('app_name'),
-        job_id: row.fetch('job_id'),
+        job_id: job_id,
         job_name: row.fetch('job_name'),
       }
-      jobs[job[:job_id]] = job
+      jobs[job_id] = job
     end
 
     @recently_processed_jobs = {}


### PR DESCRIPTION
Previous query contained columns which isn't group-by target nor
aggregators. Although MySQL accepts such query, it seems to do harm to
performance.

@cookpad/dev-infra please review