### PR TITLE
Add flag to enable verification in enqueueing step

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ And deploy it as you like.
 
 You also need to prepare MySQL, Amazon SQS and Amazon S3.
 
+#### For sandbox environment
+Barbeque's enqueue API tries to be independent of MySQL by design.
+Although that design policy, verifying the enqueued job is useful in some environment (such as sandboxed environment).
+Passing `BARBEQUE_VERIFY_ENQUEUED_JOBS=1` to the Web API server enables the feature that verifies the enqueued job by accessing MySQL.
+
 ### Worker
 
 ```bash

--- a/app/controllers/barbeque/api/job_executions_controller.rb
+++ b/app/controllers/barbeque/api/job_executions_controller.rb
@@ -8,6 +8,10 @@ class Barbeque::Api::JobExecutionsController < Barbeque::Api::ApplicationControl
     any :message, required: true, description: 'Free-format JSON'
   end
 
+  rescue_from Barbeque::MessageEnqueuingService::BadRequest do |exc|
+    render status: 400, json: { error: exc.message }
+  end
+
   private
 
   def require_resources


### PR DESCRIPTION
Barbeque's enqueue API tries to be independent of MySQL by design.
Although that design policy, verifying the enqueued job is useful in
some environment (such as sandboxed environment).  Passing
`BARBEQUE_VERIFY_ENQUEUED_JOBS=1` to the Web API server enables the
feature that verifies the enqueued job by accessing MySQL.

@cookpad/dev-infra please review