### PR TITLE
Fix Barbeque::SnsSubscriptionsController#fetch_sns_topic_arns

### DIFF
--- a/app/controllers/barbeque/sns_subscriptions_controller.rb
+++ b/app/controllers/barbeque/sns_subscriptions_controller.rb
@@ -44,6 +44,6 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
   private
 
   def fetch_sns_topic_arns
-    Barbeque::SNSSubscriptionService.sns_client.list_topics.topics.map(&:topic_arn)
+    Barbeque::SNSSubscriptionService.sns_client.list_topics.flat_map(&:topics).map(&:topic_arn)
   end
 end


### PR DESCRIPTION
Aws::SNS::Client#list_topics returns up to 100 topics. This
change allows to fetch all topics when there are more than 100
topics.