### PR TITLE
Support cross-region SNS topic subscription

### DIFF
--- a/app/controllers/barbeque/sns_subscriptions_controller.rb
+++ b/app/controllers/barbeque/sns_subscriptions_controller.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk-sns'
-
 class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
   def index
     @sns_subscriptions = Barbeque::SNSSubscription.all
@@ -47,10 +45,10 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
 
   def fetch_sns_topic_arns
     if Barbeque.config.sns_regions.empty?
-      Aws::SNS::Client.new.list_topics.flat_map(&:topics).map(&:topic_arn)
+      Barbeque::SNSSubscriptionService.sns_client.list_topics.flat_map(&:topics).map(&:topic_arn)
     else
       Barbeque.config.sns_regions.flat_map do |region|
-        Aws::SNS::Client.new(region: region).list_topics.flat_map(&:topics).map(&:topic_arn)
+        Barbeque::SNSSubscriptionService.sns_client(region).list_topics.flat_map(&:topics).map(&:topic_arn)
       end
     end
   end

--- a/app/models/barbeque/sns_subscription.rb
+++ b/app/models/barbeque/sns_subscription.rb
@@ -7,5 +7,9 @@ module Barbeque
     validates :topic_arn,
       uniqueness: { scope: :job_queue, message: 'should be set with only one queue' },
       presence: true
+
+    def region
+      /\Aarn:aws:sns:([a-z0-9-]+):/.match(topic_arn)[1]
+    end
   end
 end

--- a/app/models/barbeque/sns_subscription.rb
+++ b/app/models/barbeque/sns_subscription.rb
@@ -9,7 +9,7 @@ module Barbeque
       presence: true
 
     def region
-      /\Aarn:aws:sns:([a-z0-9-]+):/.match(topic_arn)[1]
+      topic_arn.slice(/\Aarn:aws:sns:([a-z0-9-]+):/, 1)
     end
   end
 end

--- a/app/services/barbeque/sns_subscription_service.rb
+++ b/app/services/barbeque/sns_subscription_service.rb
@@ -6,10 +6,6 @@ class Barbeque::SNSSubscriptionService
     @sqs_client ||= Aws::SQS::Client.new
   end
 
-  def self.sns_client
-    @sns_client ||= Aws::SNS::Client.new
-  end
-
   # @param [Barbeque::SNSSubscription] sns_subscription
   # @return [Boolean] `true` if succeeded to subscribe
   def subscribe(sns_subscription)
@@ -43,10 +39,6 @@ class Barbeque::SNSSubscriptionService
 
   def sqs_client
     Barbeque::SNSSubscriptionService.sqs_client
-  end
-
-  def sns_client
-    Barbeque::SNSSubscriptionService.sns_client
   end
 
   # @param [Barbeque::SNSSubscription] sns_subscription
@@ -98,6 +90,7 @@ class Barbeque::SNSSubscriptionService
     )
     queue_arn = sqs_attrs.attributes['QueueArn']
 
+    sns_client = Aws::SNS::Client.new(region: sns_subscription.region)
     sns_client.subscribe(
       topic_arn: sns_subscription.topic_arn,
       protocol: 'sqs',
@@ -112,6 +105,8 @@ class Barbeque::SNSSubscriptionService
       attribute_names: ['QueueArn'],
     )
     queue_arn = sqs_attrs.attributes['QueueArn']
+
+    sns_client = Aws::SNS::Client.new(region: sns_subscription.region)
 
     subscriptions = sns_client.list_subscriptions_by_topic(
       topic_arn: sns_subscription.topic_arn,

--- a/lib/barbeque/config.rb
+++ b/lib/barbeque/config.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 module Barbeque
   class Config
-    attr_accessor :exception_handler, :executor, :executor_options, :sqs_receive_message_wait_time, :maximum_concurrent_executions, :runner_wait_seconds
+    attr_accessor :exception_handler, :executor, :executor_options, :sqs_receive_message_wait_time, :maximum_concurrent_executions, :runner_wait_seconds, :sns_regions
 
     def initialize(options = {})
       options.each do |key, value|
@@ -27,6 +27,7 @@ module Barbeque
       # nil means unlimited
       'maximum_concurrent_executions' => nil,
       'runner_wait_seconds' => 10,
+      'sns_regions' => [],
     }
 
     def config

--- a/spec/controllers/barbeque/job_definitions_controller_spec.rb
+++ b/spec/controllers/barbeque/job_definitions_controller_spec.rb
@@ -191,8 +191,8 @@ describe Barbeque::JobDefinitionsController do
       let(:subscription_arn) { 'arn:aws:sns:ap-northeast-1:012345678912:barbeque-spec:01234567-89ab-cdef-0123-456789abcdef' }
 
       before do
-        allow(Barbeque::SNSSubscriptionService).to receive(:sns_client).and_return(sns_client)
         allow(Barbeque::SNSSubscriptionService).to receive(:sqs_client).and_return(sqs_client)
+        allow(Aws::SNS::Client).to receive(:new).with(region: 'ap-northeast-1').and_return(sns_client)
 
         allow(sqs_client).to receive(:get_queue_attributes).
           with(queue_url: sns_subscription.job_queue.queue_url, attribute_names: ['QueueArn']).

--- a/spec/controllers/barbeque/job_definitions_controller_spec.rb
+++ b/spec/controllers/barbeque/job_definitions_controller_spec.rb
@@ -191,8 +191,8 @@ describe Barbeque::JobDefinitionsController do
       let(:subscription_arn) { 'arn:aws:sns:ap-northeast-1:012345678912:barbeque-spec:01234567-89ab-cdef-0123-456789abcdef' }
 
       before do
+        allow(Barbeque::SNSSubscriptionService).to receive(:sns_client).with('ap-northeast-1').and_return(sns_client)
         allow(Barbeque::SNSSubscriptionService).to receive(:sqs_client).and_return(sqs_client)
-        allow(Aws::SNS::Client).to receive(:new).with(region: 'ap-northeast-1').and_return(sns_client)
 
         allow(sqs_client).to receive(:get_queue_attributes).
           with(queue_url: sns_subscription.job_queue.queue_url, attribute_names: ['QueueArn']).

--- a/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
+++ b/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
@@ -5,7 +5,7 @@ describe Barbeque::SnsSubscriptionsController do
 
   before do
     allow(Barbeque::SNSSubscriptionService).to receive(:sqs_client).and_return(sqs_client)
-    allow(Aws::SNS::Client).to receive(:new).with(region: 'ap-northeast-1').and_return(sns_client)
+    allow(Barbeque::SNSSubscriptionService).to receive(:sns_client).with('ap-northeast-1').and_return(sns_client)
   end
 
   describe '#create' do

--- a/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
+++ b/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
@@ -5,7 +5,7 @@ describe Barbeque::SnsSubscriptionsController do
 
   before do
     allow(Barbeque::SNSSubscriptionService).to receive(:sqs_client).and_return(sqs_client)
-    allow(Barbeque::SNSSubscriptionService).to receive(:sns_client).and_return(sns_client)
+    allow(Aws::SNS::Client).to receive(:new).with(region: 'ap-northeast-1').and_return(sns_client)
   end
 
   describe '#create' do

--- a/spec/factories/sns_subscription.rb
+++ b/spec/factories/sns_subscription.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :sns_subscription, class: Barbeque::SNSSubscription do
-    sequence(:topic_arn) { |n| "arn:aws:sns:ap-northest-1:123456789012/Topic-#{n}" }
+    sequence(:topic_arn) { |n| "arn:aws:sns:ap-northeast-1:123456789012/Topic-#{n}" }
     job_queue
     job_definition
   end


### PR DESCRIPTION
I would like to support subscribing a topic in a different region from the SQS queue.

I came up with a few options:

1. Select a region from all regions first and then select a topic from the list of topics in the region
2. Input the ARN of the topic to subscribe directly
3. Select a topic from all topics in the regions configured beforehand

This is an implementation of the third option, which involves no change in UI.