### PR TITLE
Add delay_seconds parameter to support SQS's delay_seconds

### DIFF
--- a/app/controllers/barbeque/api/job_executions_controller.rb
+++ b/app/controllers/barbeque/api/job_executions_controller.rb
@@ -6,6 +6,7 @@ class Barbeque::Api::JobExecutionsController < Barbeque::Api::ApplicationControl
     string :job, required: true, description: 'Class of Job to be enqueued'
     string :queue, required: true, description: 'Queue name to enqueue a job'
     any :message, required: true, description: 'Free-format JSON'
+    integer :delay_seconds, description: 'Set message timer of SQS'
   end
 
   rescue_from Barbeque::MessageEnqueuingService::BadRequest do |exc|
@@ -36,6 +37,7 @@ class Barbeque::Api::JobExecutionsController < Barbeque::Api::ApplicationControl
       job:         params[:job],
       queue:       params[:queue],
       message:     params[:message],
+      delay_seconds: params[:delay_seconds],
     ).run
   end
 

--- a/app/services/barbeque/message_enqueuing_service.rb
+++ b/app/services/barbeque/message_enqueuing_service.rb
@@ -15,11 +15,13 @@ class Barbeque::MessageEnqueuingService
   # @param [String] job
   # @param [Object] message
   # @param [String] queue
-  def initialize(application:, job:, message:, queue: nil)
+  # @param [Integer, nil] delay_seconds
+  def initialize(application:, job:, message:, queue: nil, delay_seconds:)
     @application = application
     @job         = job
     @queue       = queue || DEFAULT_QUEUE
     @message     = message
+    @delay_seconds = delay_seconds
   end
 
   # @return [String] message_id
@@ -33,8 +35,11 @@ class Barbeque::MessageEnqueuingService
     response = Barbeque::MessageEnqueuingService.sqs_client.send_message(
       queue_url:    queue_url,
       message_body: build_message.to_json,
+      delay_seconds: @delay_seconds,
     )
     response.message_id
+  rescue Aws::SQS::Errors::InvalidParameterValue => e
+    raise BadRequest.new(e.message)
   end
 
   private

--- a/app/services/barbeque/message_enqueuing_service.rb
+++ b/app/services/barbeque/message_enqueuing_service.rb
@@ -16,7 +16,7 @@ class Barbeque::MessageEnqueuingService
   # @param [Object] message
   # @param [String] queue
   # @param [Integer, nil] delay_seconds
-  def initialize(application:, job:, message:, queue: nil, delay_seconds:)
+  def initialize(application:, job:, message:, queue: nil, delay_seconds: nil)
     @application = application
     @job         = job
     @queue       = queue || DEFAULT_QUEUE

--- a/doc/api/job_executions.md
+++ b/doc/api/job_executions.md
@@ -5,7 +5,7 @@ Shows a status of a job_execution.
 
 #### Request
 ```
-GET /v1/job_executions/71622470-942a-45c1-adbd-199c83685333 HTTP/1.1
+GET /v1/job_executions/44b34792-99c2-4165-b0a7-97ba8cb67701 HTTP/1.1
 Accept: application/json
 Content-Length: 0
 Content-Type: application/json
@@ -18,14 +18,14 @@ HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 81
 Content-Type: application/json; charset=utf-8
-ETag: W/"b7992954a605e364d55d46d2915afa4d"
-X-Request-Id: 8602e1f1-f40d-4c4b-bf8c-7b7b1eee3d47
-X-Runtime: 0.008705
+ETag: W/"162d4526406d7cc92778f7c9a77770b5"
+X-Request-Id: 752ecffe-9fa0-471b-9c18-9da21f689b28
+X-Runtime: 0.012975
 
 {
-  "message_id": "71622470-942a-45c1-adbd-199c83685333",
+  "message_id": "44b34792-99c2-4165-b0a7-97ba8cb67701",
   "status": "success",
-  "id": 773
+  "id": 683
 }
 ```
 
@@ -36,7 +36,7 @@ Shows url to job_execution.
 
 #### Request
 ```
-GET /v1/job_executions/bbbf6ae8-a0f6-4d87-9eef-005749b22d2e?fields=__default__,html_url HTTP/1.1
+GET /v1/job_executions/d54860cb-f374-4ef2-b19e-1662ce714c61?fields=__default__,html_url HTTP/1.1
 Accept: application/json
 Content-Length: 0
 Content-Type: application/json
@@ -49,15 +49,15 @@ HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 169
 Content-Type: application/json; charset=utf-8
-ETag: W/"2b34bdd76bb52134a2232b91c94749e9"
-X-Request-Id: 2180413d-6aef-435c-94d6-7107189c669f
-X-Runtime: 0.002495
+ETag: W/"83d62488e2a41e9531c68de74c956ab0"
+X-Request-Id: 2edf1ac6-cea2-42b7-a47a-b033c9981ff2
+X-Runtime: 0.002832
 
 {
-  "message_id": "bbbf6ae8-a0f6-4d87-9eef-005749b22d2e",
+  "message_id": "d54860cb-f374-4ef2-b19e-1662ce714c61",
   "status": "success",
-  "id": 774,
-  "html_url": "http://www.example.com/job_executions/bbbf6ae8-a0f6-4d87-9eef-005749b22d2e"
+  "id": 684,
+  "html_url": "http://www.example.com/job_executions/d54860cb-f374-4ef2-b19e-1662ce714c61"
 }
 ```
 
@@ -68,7 +68,7 @@ Returns message of the job_execution.
 
 #### Request
 ```
-GET /v1/job_executions/2a258cee-6459-4cea-9dda-73b52c70d76e?fields=__default__,message HTTP/1.1
+GET /v1/job_executions/ece0e578-a9ac-4eb5-ac8d-5a02270629c1?fields=__default__,message HTTP/1.1
 Accept: application/json
 Content-Length: 0
 Content-Type: application/json
@@ -81,14 +81,14 @@ HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 111
 Content-Type: application/json; charset=utf-8
-ETag: W/"ca08e470e43fabd91348308004d3864a"
-X-Request-Id: 537a8605-bca0-4dd2-9be4-78b9bc5a478d
-X-Runtime: 0.002163
+ETag: W/"03c274fb6c9afa0dc90cd8eec1e77dcf"
+X-Request-Id: fd15b690-9a0d-457c-b672-9721b28d5bca
+X-Runtime: 0.005220
 
 {
-  "message_id": "2a258cee-6459-4cea-9dda-73b52c70d76e",
+  "message_id": "ece0e578-a9ac-4eb5-ac8d-5a02270629c1",
   "status": "success",
-  "id": 775,
+  "id": 685,
   "message": {
     "recipe_id": 12345
   }
@@ -103,6 +103,7 @@ Enqueues a job execution.
 * `job` string (required) - Class of Job to be enqueued
 * `queue` string (required) - Queue name to enqueue a job
 * `message` any (required) - Free-format JSON
+* `delay_seconds` integer - Set message timer of SQS
 
 ### Example
 
@@ -130,12 +131,60 @@ HTTP/1.1 201
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 82
 Content-Type: application/json; charset=utf-8
-ETag: W/"9d45a3c5732258dd568f77952ea2bc80"
-X-Request-Id: 8ca08e5a-1604-499f-8e10-72c4acbdfa3e
-X-Runtime: 0.002180
+ETag: W/"413ca32999e1a97bebde87741a53d078"
+X-Request-Id: 8bc996f6-2b20-4bf6-a7f7-0980f796f0aa
+X-Runtime: 0.002134
 
 {
-  "message_id": "3385716b-9a26-4563-9e51-33fa7787a2c9",
+  "message_id": "e91b56d8-30a9-4331-93f6-1296216c7407",
+  "status": "pending",
+  "id": null
+}
+```
+
+## POST /v2/job_executions
+Enqueues a job execution with delay_seconds.
+
+### Parameters
+* `application` string (required) - Application name of the job
+* `job` string (required) - Class of Job to be enqueued
+* `queue` string (required) - Queue name to enqueue a job
+* `message` any (required) - Free-format JSON
+* `delay_seconds` integer - Set message timer of SQS
+
+### Example
+
+#### Request
+```
+POST /v2/job_executions HTTP/1.1
+Accept: application/json
+Content-Length: 109
+Content-Type: application/json
+Host: www.example.com
+
+{
+  "application": "blog",
+  "job": "NotifyAuthor",
+  "queue": "queue-105",
+  "message": {
+    "recipe_id": 1
+  },
+  "delay_seconds": 300
+}
+```
+
+#### Response
+```
+HTTP/1.1 201
+Cache-Control: max-age=0, private, must-revalidate
+Content-Length: 82
+Content-Type: application/json; charset=utf-8
+ETag: W/"dabbb98b9040a53f74a93682f6a83ccd"
+X-Request-Id: b58503df-873d-4544-868a-021ffdcde58a
+X-Runtime: 0.004408
+
+{
+  "message_id": "8f5cbe66-8dee-433e-ba90-30cbf36eddfe",
   "status": "pending",
   "id": null
 }

--- a/doc/api/job_retries.md
+++ b/doc/api/job_retries.md
@@ -8,7 +8,7 @@ Enqueues a message to retry a specified message.
 
 #### Request
 ```
-POST /v1/job_executions/de79c839-1952-4b24-9afc-7651070202ad/retries HTTP/1.1
+POST /v1/job_executions/7d659a22-b53e-4137-8f70-6416a1ce1c34/retries HTTP/1.1
 Accept: application/json
 Content-Length: 0
 Content-Type: application/json
@@ -21,12 +21,12 @@ HTTP/1.1 201
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 72
 Content-Type: application/json; charset=utf-8
-ETag: W/"9002f23876371ddabaf452d6b814473f"
-X-Request-Id: e96d66f9-b6d8-42b2-8df4-e5b2df61085a
-X-Runtime: 0.005293
+ETag: W/"352714e6aa30cf531412bbaf085e21fb"
+X-Request-Id: 14df67d9-6d10-46e8-b86d-0e8748387035
+X-Runtime: 0.006126
 
 {
-  "message_id": "e18bc218-370e-4b8c-a586-732fcb53ea3d",
+  "message_id": "e5dec945-952a-4256-afe4-b728430a9b75",
   "status": "pending"
 }
 ```

--- a/doc/api/revision_locks.md
+++ b/doc/api/revision_locks.md
@@ -8,7 +8,7 @@ Updates a tag of docker_image.
 
 #### Request
 ```
-POST /v1/apps/app-104/revision_lock HTTP/1.1
+POST /v1/apps/app-105/revision_lock HTTP/1.1
 Accept: application/json
 Content-Length: 55
 Content-Type: application/json
@@ -26,8 +26,8 @@ Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 55
 Content-Type: application/json; charset=utf-8
 ETag: W/"a3f0b3d8c32ee1e318357b5276e50a3c"
-X-Request-Id: 3173b89d-b5ce-4464-af51-6d17684cf3de
-X-Runtime: 0.008263
+X-Request-Id: aec3ef82-1987-45c3-9f00-1b400bcaa171
+X-Runtime: 0.009411
 
 {
   "revision": "798926db1e623cd51245b70b1f1acb40d780ddc1"
@@ -41,7 +41,7 @@ Updates a tag of docker_image.
 
 #### Request
 ```
-DELETE /v1/apps/app-106/revision_lock HTTP/1.1
+DELETE /v1/apps/app-107/revision_lock HTTP/1.1
 Accept: application/json
 Content-Length: 0
 Content-Type: application/json
@@ -52,6 +52,6 @@ Host: www.example.com
 ```
 HTTP/1.1 204
 Cache-Control: no-cache
-X-Request-Id: b968f324-529b-4b79-a3e7-70f0f6b01e48
-X-Runtime: 0.003531
+X-Request-Id: 016e5584-500a-4e9f-aa08-d5d8e711dce3
+X-Runtime: 0.010075
 ```

--- a/doc/toc.md
+++ b/doc/toc.md
@@ -4,6 +4,7 @@
  * [GET /v1/job_executions/:message_id](api/job_executions.md#get-v1job_executionsmessage_id-1)
  * [GET /v1/job_executions/:message_id](api/job_executions.md#get-v1job_executionsmessage_id-2)
  * [POST /v2/job_executions](api/job_executions.md#post-v2job_executions)
+ * [POST /v2/job_executions](api/job_executions.md#post-v2job_executions-1)
 * [api/job_retries.md](api/job_retries.md)
  * [POST /v1/job_executions/:job_execution_message_id/retries](api/job_retries.md#post-v1job_executionsjob_execution_message_idretries)
 * [api/revision_locks.md](api/revision_locks.md)

--- a/spec/services/message_enqueuing_service_spec.rb
+++ b/spec/services/message_enqueuing_service_spec.rb
@@ -31,7 +31,6 @@ describe Barbeque::MessageEnqueuingService do
         queue:   job_queue.name,
         message: message,
         application: application,
-        delay_seconds: nil,
       ).run
       expect(result).to eq(message_id)
     end
@@ -47,7 +46,6 @@ describe Barbeque::MessageEnqueuingService do
             queue:   queue_name,
             message: message,
             application: application,
-            delay_seconds: nil,
           ).run
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
@@ -72,7 +70,6 @@ describe Barbeque::MessageEnqueuingService do
           queue: job_queue.name,
           message: message,
           application: application,
-          delay_seconds: nil,
         ).run
         expect(result).to eq(message_id)
       end

--- a/spec/services/message_enqueuing_service_spec.rb
+++ b/spec/services/message_enqueuing_service_spec.rb
@@ -23,6 +23,7 @@ describe Barbeque::MessageEnqueuingService do
           'Job'         => job,
           'Message'     => message,
         }.to_json,
+        delay_seconds: nil,
       ).and_return(send_message_result)
 
       result = Barbeque::MessageEnqueuingService.new(
@@ -30,6 +31,7 @@ describe Barbeque::MessageEnqueuingService do
         queue:   job_queue.name,
         message: message,
         application: application,
+        delay_seconds: nil,
       ).run
       expect(result).to eq(message_id)
     end
@@ -45,6 +47,7 @@ describe Barbeque::MessageEnqueuingService do
             queue:   queue_name,
             message: message,
             application: application,
+            delay_seconds: nil,
           ).run
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
@@ -69,8 +72,64 @@ describe Barbeque::MessageEnqueuingService do
           queue: job_queue.name,
           message: message,
           application: application,
+          delay_seconds: nil,
         ).run
         expect(result).to eq(message_id)
+      end
+    end
+
+    context 'with delay_seconds' do
+      let(:delay_seconds) { 300 }
+
+      it 'enqueues a message with delay_seconds' do
+        expect(sqs_client).to receive(:send_message).with(
+          queue_url: job_queue.queue_url,
+          message_body: {
+            'Type'        => 'JobExecution',
+            'Application' => application,
+            'Job'         => job,
+            'Message'     => message,
+          }.to_json,
+          delay_seconds: delay_seconds,
+        ).and_return(send_message_result)
+
+        result = Barbeque::MessageEnqueuingService.new(
+          job:     job,
+          queue:   job_queue.name,
+          message: message,
+          application: application,
+          delay_seconds: delay_seconds,
+        ).run
+        expect(result).to eq(message_id)
+      end
+
+      context 'with too large delay_seconds' do
+        let(:delay_seconds) { 6000 }
+        let(:invalid_parameter_value_exception) do
+          Aws::SQS::Errors::InvalidParameterValue.new(nil, "Value #{delay_seconds} for parameter DelaySeconds is invalid. Reason: DelaySeconds must be >= 0 and <= 900.")
+        end
+
+        it 'raises BadRequest' do
+          expect(sqs_client).to receive(:send_message).with(
+            queue_url: job_queue.queue_url,
+            message_body: {
+              'Type'        => 'JobExecution',
+              'Application' => application,
+              'Job'         => job,
+              'Message'     => message,
+            }.to_json,
+            delay_seconds: delay_seconds,
+          ).and_raise(invalid_parameter_value_exception)
+
+          service = Barbeque::MessageEnqueuingService.new(
+            job:     job,
+            queue:   job_queue.name,
+            message: message,
+            application: application,
+            delay_seconds: delay_seconds,
+          )
+          expect { service.run }.to raise_error(Barbeque::MessageEnqueuingService::BadRequest)
+        end
       end
     end
   end


### PR DESCRIPTION
This parameter is required to implement ActiveJob's enqueue_at method.
https://github.com/cookpad/barbeque_client/blob/v0.9.1/lib/active_job/queue_adapters/barbeque_adapter.rb#L20-L24
Note that SQS only supports delay_seconds <= 15 minutes. When
barbeque_client enqueues a job with unsupported timestamp, 400 error is
returned.
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html

@cookpad/dev-infra please review