### PR TITLE
Stop deleting job executions

### DIFF
--- a/app/controllers/barbeque/job_executions_controller.rb
+++ b/app/controllers/barbeque/job_executions_controller.rb
@@ -10,6 +10,9 @@ class Barbeque::JobExecutionsController < Barbeque::ApplicationController
       end
     end
     @job_execution = Barbeque::JobExecution.find_by!(message_id: params[:message_id])
+    # Return 404 when job_definition or app is deleted
+    @job_definition = Barbeque::JobDefinition.find(@job_execution.job_definition_id)
+    @app = Barbeque::App.find(@job_definition.app_id)
     @log = @job_execution.execution_log
     @job_retries = @job_execution.job_retries.order(id: :desc)
   end

--- a/app/controllers/barbeque/job_retries_controller.rb
+++ b/app/controllers/barbeque/job_retries_controller.rb
@@ -2,6 +2,9 @@ class Barbeque::JobRetriesController < Barbeque::ApplicationController
   def show
     @job_retry = Barbeque::JobRetry.find(params[:id])
     @job_execution = @job_retry.job_execution
+    # Return 404 when job_definition or app is deleted
+    @job_definition = Barbeque::JobDefinition.find(@job_execution.job_definition_id)
+    @app = Barbeque::App.find(@job_definition.app_id)
 
     if params[:job_execution_message_id] != @job_execution.message_id
       redirect_to([@job_execution, @job_retry])

--- a/app/models/barbeque/job_definition.rb
+++ b/app/models/barbeque/job_definition.rb
@@ -1,6 +1,6 @@
 class Barbeque::JobDefinition < Barbeque::ApplicationRecord
   belongs_to :app
-  has_many :job_executions, dependent: :destroy
+  has_many :job_executions
   has_many :sns_subscriptions, class_name: 'SNSSubscription'
   has_one :slack_notification, dependent: :destroy
 

--- a/app/models/barbeque/job_queue.rb
+++ b/app/models/barbeque/job_queue.rb
@@ -2,7 +2,7 @@ class Barbeque::JobQueue < Barbeque::ApplicationRecord
   SQS_NAME_PREFIX = ENV['BARBEQUE_SQS_NAME_PREFIX'] || 'Barbeque-'
   SQS_NAME_MAX_LENGTH = 80
 
-  has_many :job_executions, dependent: :destroy
+  has_many :job_executions
   has_many :sns_subscriptions, class_name: 'SNSSubscription', dependent: :destroy
 
   # SQS queue allows [a-zA-Z0-9_-]+ as queue name. Its maximum length is 80.

--- a/app/views/barbeque/job_executions/show.html.haml
+++ b/app/views/barbeque/job_executions/show.html.haml
@@ -1,10 +1,9 @@
-- content_for(:title, "Job execution ##{@job_execution.id} of #{@job_execution.job_definition.job} - Barbeque")
+- content_for(:title, "Job execution ##{@job_execution.id} of #{@job_definition.job} - Barbeque")
 - content_for(:header) do
   %ol.breadcrumb
-    - job_definition = @job_execution.job_definition
     %li= link_to('Home', root_path)
-    %li= link_to(job_definition.app.name, app_path(job_definition.app.id))
-    %li= link_to(job_definition.job, job_definition_path(job_definition.id))
+    %li= link_to(@app.name, app_path(@app.id))
+    %li= link_to(@job_definition.job, job_definition_path(@job_definition.id))
     %li.active #{@job_execution.message_id}
 
 .row
@@ -15,12 +14,12 @@
           .col-md-10
             %h3.box-title.with_padding
               \##{@job_execution.id} of
-              = link_to @job_execution.job_definition do
-                #{@job_execution.job_definition.job}
+              = link_to @job_definition do
+                #{@job_definition.job}
           - if @job_execution.retryable?
             .col-md-2
               = link_to job_execution_retry_path(@job_execution), method: :post, class: 'btn btn-default btn-block pull-right',
-                data: { disable_with: 'retrying...', confirm: "Are you sure to retry #{@job_execution.job_definition.job} ##{@job_execution.id}?" } do
+                data: { disable_with: 'retrying...', confirm: "Are you sure to retry #{@job_definition.job} ##{@job_execution.id}?" } do
                 Retry
 
       .box-body
@@ -107,4 +106,4 @@
         - else
           Log was not found.
 
-= link_to 'Back', job_definition_path(@job_execution.job_definition)
+= link_to 'Back', job_definition_path(@job_definition)

--- a/app/views/barbeque/job_retries/show.html.haml
+++ b/app/views/barbeque/job_retries/show.html.haml
@@ -1,12 +1,10 @@
-- content_for(:title, "Job retry ##{@job_retry.id} of #{@job_retry.job_execution.job_definition.job} - Barbeque")
+- content_for(:title, "Job retry ##{@job_retry.id} of #{@job_definition.job} - Barbeque")
 - content_for(:header) do
   %ol.breadcrumb
-    - job_execution = @job_retry.job_execution
-    - job_definition = job_execution.job_definition
     %li= link_to('Home', root_path)
-    %li= link_to(job_definition.app.name, app_path(job_definition.app.id))
-    %li= link_to(job_definition.job, job_definition_path(job_definition.id))
-    %li= link_to(job_execution.message_id, job_execution_path(job_execution))
+    %li= link_to(@app.name, app_path(@app.id))
+    %li= link_to(@job_definition.job, job_definition_path(@job_definition.id))
+    %li= link_to(@job_execution.message_id, job_execution_path(@job_execution))
     %li.active ##{@job_retry.id}
 
 .row
@@ -17,8 +15,8 @@
           .col-md-10
             %h3.box-title.with_padding
               Retry ##{@job_retry.id} of
-              = link_to @job_retry.job_definition do
-                #{@job_retry.job_definition.job}
+              = link_to @job_definition do
+                #{@job_definition.job}
               = link_to @job_execution do
                 \##{@job_execution.id}
 

--- a/spec/controllers/barbeque/job_definitions_controller_spec.rb
+++ b/spec/controllers/barbeque/job_definitions_controller_spec.rb
@@ -175,12 +175,12 @@ describe Barbeque::JobDefinitionsController do
       create(:job_execution, job_definition: job_definition)
     end
 
-    it 'destroys a requested app and its executions' do
+    it 'destroys a requested app' do
       expect {
         delete :destroy, params: { id: job_definition.id }
       }.to change {
         [Barbeque::JobDefinition.count, Barbeque::JobExecution.count]
-      }.from([1, 1]).to([0, 0])
+      }.from([1, 1]).to([0, 1])
     end
 
     context 'with SNS subscriptions' do


### PR DESCRIPTION
Job executions tend to have large number of records, so deleting them is
impossible.

@cookpad/dev-infra please review