### PR TITLE
Add server-side retry feature

### DIFF
--- a/app/assets/javascripts/barbeque/job_definitions.coffee
+++ b/app/assets/javascripts/barbeque/job_definitions.coffee
@@ -8,3 +8,11 @@ jQuery ($) ->
     else
       enabledField.addClass('active')
   )
+
+  $('.enable_retry_configuration').bind('change', (event) ->
+    enabledField = $('.retry_configuration_field')
+    if event.target.value == 'true'
+      enabledField.removeClass('active')
+    else
+      enabledField.addClass('active')
+  )

--- a/app/assets/stylesheets/barbeque/job_definitions.scss
+++ b/app/assets/stylesheets/barbeque/job_definitions.scss
@@ -18,4 +18,24 @@
       display: block;
     }
   }
+
+  .retry_configuration_wrapper label {
+    font-weight: normal;
+  }
+
+  .enable_retry_configuration {
+    margin: 0 2px 0 8px;
+  }
+
+  .retry_configuration_field {
+    display: none;
+
+    label {
+      font-weight: normal;
+    }
+
+    &.active {
+      display: block;
+    }
+  }
 }

--- a/app/controllers/barbeque/job_definitions_controller.rb
+++ b/app/controllers/barbeque/job_definitions_controller.rb
@@ -6,6 +6,7 @@ class Barbeque::JobDefinitionsController < Barbeque::ApplicationController
   def show
     @job_definition = Barbeque::JobDefinition.find(params[:id])
     @job_executions = @job_definition.job_executions.order(id: :desc).page(params[:page])
+    @retry_config = @job_definition.retry_config
     @status = params[:status].presence.try(&:to_i)
     if @status
       @job_executions = @job_executions.where(status: @status)
@@ -15,6 +16,7 @@ class Barbeque::JobDefinitionsController < Barbeque::ApplicationController
   def new
     @job_definition = Barbeque::JobDefinition.new
     @job_definition.build_slack_notification
+    @job_definition.build_retry_config
     if params[:job_definition]
       @job_definition.assign_attributes(new_job_definition_params)
     end
@@ -22,8 +24,11 @@ class Barbeque::JobDefinitionsController < Barbeque::ApplicationController
 
   def edit
     @job_definition = Barbeque::JobDefinition.find(params[:id])
-    if @job_definition.slack_notification.nil?
+    unless @job_definition.slack_notification
       @job_definition.build_slack_notification
+    end
+    unless @job_definition.retry_config
+      @job_definition.build_retry_config
     end
   end
 
@@ -43,6 +48,7 @@ class Barbeque::JobDefinitionsController < Barbeque::ApplicationController
     attributes = params.require(:job_definition).permit(
       :description,
       slack_notification_attributes: slack_notification_params,
+      retry_config_attributes: retry_config_params,
     ).merge(command: command_array)
     if @job_definition.update(attributes)
       redirect_to @job_definition, notice: 'Job definition was successfully updated.'
@@ -76,6 +82,10 @@ class Barbeque::JobDefinitionsController < Barbeque::ApplicationController
 
   def slack_notification_params
     %i[id channel notify_success failure_notification_text _destroy]
+  end
+
+  def retry_config_params
+    %i[id retry_limit base_delay max_delay jitter _destroy]
   end
 
   def command_array

--- a/app/models/barbeque/job_definition.rb
+++ b/app/models/barbeque/job_definition.rb
@@ -3,6 +3,7 @@ class Barbeque::JobDefinition < Barbeque::ApplicationRecord
   has_many :job_executions
   has_many :sns_subscriptions, class_name: 'SNSSubscription'
   has_one :slack_notification, dependent: :destroy
+  has_one :retry_config, dependent: :destroy
 
   validates :job, uniqueness: { scope: :app_id }
 
@@ -12,6 +13,7 @@ class Barbeque::JobDefinition < Barbeque::ApplicationRecord
   serialize :command, Array
 
   accepts_nested_attributes_for :slack_notification, allow_destroy: true
+  accepts_nested_attributes_for :retry_config, allow_destroy: true
 
   DATE_HOUR_SQL = 'date_format(created_at, "%Y-%m-%d %H:00:00")'
 

--- a/app/models/barbeque/retry_config.rb
+++ b/app/models/barbeque/retry_config.rb
@@ -1,0 +1,24 @@
+class Barbeque::RetryConfig < Barbeque::ApplicationRecord
+  belongs_to :job_definition
+
+  validates :retry_limit, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :base_delay, numericality: { greater_than: 0.0 }, allow_nil: true
+  validates :max_delay, numericality: { greater_than: 0 }, allow_nil: true
+
+  def should_retry?(retries)
+    retries < retry_limit
+  end
+
+  # This algorithm is based on "Exponential Backoff And Jitter" article
+  # https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+  def delay_seconds(retries)
+    delay = 2 ** retries * base_delay
+    if max_delay
+      delay = [delay, max_delay].min
+    end
+    if jitter
+      delay = Kernel.rand(0 .. delay)
+    end
+    delay
+  end
+end

--- a/app/views/barbeque/job_definitions/_form.html.haml
+++ b/app/views/barbeque/job_definitions/_form.html.haml
@@ -40,6 +40,7 @@
           = f.text_area :description, class: 'form-control', rows: 10
 
       = render 'slack_notification_field', job_definition: @job_definition
+      = render 'retry_configuration_field', job_definition: @job_definition
 
       .form-group
         = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/barbeque/job_definitions/_retry_configuration_field.html.haml
+++ b/app/views/barbeque/job_definitions/_retry_configuration_field.html.haml
@@ -1,0 +1,38 @@
+= fields_for(job_definition) do |job_definition_f|
+  = job_definition_f.fields_for(:retry_config) do |f|
+    = f.hidden_field :id
+
+    .row
+      .col-md-8
+        %label Retry configuration
+
+    - retry_enabled = f.object.persisted?
+    .row.form-group
+      .col-md-8.retry_configuration_wrapper
+        = f.label :_destroy_true do
+          = f.radio_button :_destroy, true, class: 'enable_retry_configuration', checked: !retry_enabled
+          No
+        = f.label :_destroy_false do
+          = f.radio_button :_destroy, false, class: 'enable_retry_configuration', checked: retry_enabled
+          Yes
+
+    .retry_configuration_field{ class: ('active' if retry_enabled) }
+      .row.form-group
+        .col-md-4
+          = f.label :retry_limit
+          = f.number_field :retry_limit, min: 1, class: 'form-control'
+
+      .row.form-group
+        .col-md-4
+          = f.label :base_delay
+          = f.number_field :base_delay, min: 0.1, step: 0.1, class: 'form-control'
+
+      .row.form-group
+        .col-md-4
+          = f.label :max_delay
+          = f.number_field :max_delay, min: 1, class: 'form-control'
+
+      .row.form-group
+        .col-md-4
+          = f.label :jitter
+          = f.check_box :jitter

--- a/app/views/barbeque/job_definitions/show.html.haml
+++ b/app/views/barbeque/job_definitions/show.html.haml
@@ -36,6 +36,13 @@
                   Yes (#{@job_definition.slack_notification.channel})
                 - else
                   No
+            %tr
+              %th Retry configuration
+              %td
+                - if @retry_config
+                  Yes (retry_limit=#{@retry_config.retry_limit} base_delay=#{@retry_config.base_delay} max_delay=#{@retry_config.max_delay || '+inf'} jitter=#{@retry_config.jitter ? 'enabled' : 'disabled'})
+                - else
+                  No
 
         = link_to 'Edit', edit_job_definition_path(@job_definition), class: 'btn btn-primary'
         = link_to 'Destroy', job_definition_path(@job_definition),

--- a/db/migrate/20190221050714_create_barbeque_retry_configs.rb
+++ b/db/migrate/20190221050714_create_barbeque_retry_configs.rb
@@ -1,0 +1,14 @@
+class CreateBarbequeRetryConfigs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :barbeque_retry_configs, options: 'ENGINE=InnoDB ROW_FORMAT=dynamic DEFAULT CHARSET=utf8mb4' do |t|
+      t.integer :job_definition_id, null: false
+      t.integer :retry_limit, null: false, default: 3
+      t.float :base_delay, null: false, default: '0.3'
+      t.integer :max_delay
+      t.boolean :jitter, default: true
+      t.timestamps
+
+      t.index [:job_definition_id], unique: true
+    end
+  end
+end

--- a/db/migrate/20190221050714_create_barbeque_retry_configs.rb
+++ b/db/migrate/20190221050714_create_barbeque_retry_configs.rb
@@ -5,7 +5,7 @@ class CreateBarbequeRetryConfigs < ActiveRecord::Migration[5.2]
       t.integer :retry_limit, null: false, default: 3
       t.float :base_delay, null: false, default: '0.3'
       t.integer :max_delay
-      t.boolean :jitter, default: true
+      t.boolean :jitter, null: false, default: true
       t.timestamps
 
       t.index [:job_definition_id], unique: true

--- a/lib/barbeque/executor/hako.rb
+++ b/lib/barbeque/executor/hako.rb
@@ -46,6 +46,7 @@ module Barbeque
           Barbeque::ExecutionLog.try_save_stdout_and_stderr(job_execution, stdout, stderr)
           job_execution.update!(status: :failed, finished_at: Time.zone.now)
           Barbeque::SlackNotifier.notify_job_execution(job_execution)
+          job_execution.retry_if_possible!
         end
       end
 
@@ -71,6 +72,7 @@ module Barbeque
             job_execution.update!(status: :failed)
           end
           Barbeque::SlackNotifier.notify_job_retry(job_retry)
+          job_execution.retry_if_possible!
         end
       end
 
@@ -87,6 +89,9 @@ module Barbeque
           end
           job_execution.update!(status: status, finished_at: task.stopped_at)
           Barbeque::SlackNotifier.notify_job_execution(job_execution)
+          if status == :failed
+            job_execution.retry_if_possible!
+          end
         end
       end
 
@@ -107,6 +112,9 @@ module Barbeque
             job_execution.update!(status: status)
           end
           Barbeque::SlackNotifier.notify_job_retry(job_retry)
+          if status == :failed
+            job_execution.retry_if_possible!
+          end
         end
       end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -86,7 +86,7 @@ ActiveRecord::Schema.define(version: 2019_02_21_050714) do
     t.integer "retry_limit", default: 3, null: false
     t.float "base_delay", default: 0.3, null: false
     t.integer "max_delay"
-    t.boolean "jitter", default: true
+    t.boolean "jitter", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["job_definition_id"], name: "index_barbeque_retry_configs_on_job_definition_id", unique: true

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180411070937) do
+ActiveRecord::Schema.define(version: 2019_02_21_050714) do
 
-  create_table "barbeque_apps", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+  create_table "barbeque_apps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
     t.string "docker_image", null: false
     t.text "description"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20180411070937) do
     t.index ["name"], name: "index_barbeque_apps_on_name", unique: true
   end
 
-  create_table "barbeque_docker_containers", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+  create_table "barbeque_docker_containers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "message_id", null: false
     t.string "container_id", null: false
     t.datetime "created_at", null: false
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 20180411070937) do
     t.index ["message_id"], name: "index_barbeque_docker_containers_on_message_id", unique: true
   end
 
-  create_table "barbeque_ecs_hako_tasks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+  create_table "barbeque_ecs_hako_tasks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "message_id", null: false
     t.string "cluster", null: false
     t.string "task_arn", null: false
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20180411070937) do
     t.index ["message_id"], name: "index_barbeque_ecs_hako_tasks_on_message_id", unique: true
   end
 
-  create_table "barbeque_job_definitions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+  create_table "barbeque_job_definitions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "job", null: false
     t.integer "app_id", null: false
     t.string "command", null: false
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 20180411070937) do
     t.index ["job", "app_id"], name: "index_barbeque_job_definitions_on_job_and_app_id", unique: true
   end
 
-  create_table "barbeque_job_executions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+  create_table "barbeque_job_executions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "message_id", null: false
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 20180411070937) do
     t.index ["status"], name: "index_barbeque_job_executions_on_status"
   end
 
-  create_table "barbeque_job_queues", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+  create_table "barbeque_job_queues", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.string "queue_url", null: false
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20180411070937) do
     t.index ["name"], name: "index_barbeque_job_queues_on_name", unique: true
   end
 
-  create_table "barbeque_job_retries", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+  create_table "barbeque_job_retries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "message_id", null: false
     t.integer "job_execution_id", null: false
     t.integer "status", default: 0, null: false
@@ -81,7 +81,18 @@ ActiveRecord::Schema.define(version: 20180411070937) do
     t.index ["message_id"], name: "index_barbeque_job_retries_on_message_id", unique: true
   end
 
-  create_table "barbeque_slack_notifications", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+  create_table "barbeque_retry_configs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+    t.integer "job_definition_id", null: false
+    t.integer "retry_limit", default: 3, null: false
+    t.float "base_delay", default: 0.3, null: false
+    t.integer "max_delay"
+    t.boolean "jitter", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["job_definition_id"], name: "index_barbeque_retry_configs_on_job_definition_id", unique: true
+  end
+
+  create_table "barbeque_slack_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "job_definition_id"
     t.string "channel", null: false
     t.boolean "notify_success", default: false, null: false
@@ -90,7 +101,7 @@ ActiveRecord::Schema.define(version: 20180411070937) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "barbeque_sns_subscriptions", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "barbeque_sns_subscriptions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "topic_arn", null: false
     t.integer "job_queue_id", null: false
     t.integer "job_definition_id", null: false

--- a/spec/factories/retry_config.rb
+++ b/spec/factories/retry_config.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :retry_config, class: Barbeque::RetryConfig do
+  end
+end

--- a/spec/models/barbeque/retry_config_spec.rb
+++ b/spec/models/barbeque/retry_config_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Barbeque::RetryConfig do
+  let(:job_definition) { FactoryBot.create(:job_definition) }
+  let(:retry_config) { FactoryBot.create(:retry_config, job_definition: job_definition) }
+
+  describe '#delay_seconds' do
+    it 'returns delay seconds with jitter by default' do
+      expect(retry_config.delay_seconds(0)).to be_between(0, 0.3)
+      expect(retry_config.delay_seconds(1)).to be_between(0, 0.6)
+      expect(retry_config.delay_seconds(2)).to be_between(0, 1.2)
+    end
+
+    context 'without jitter' do
+      before do
+        retry_config.update!(jitter: false)
+      end
+
+      it 'returns delay seconds without randomness' do
+        expect(retry_config.delay_seconds(0)).to be_within(0.1).of(0.3)
+        expect(retry_config.delay_seconds(1)).to be_within(0.1).of(0.6)
+        expect(retry_config.delay_seconds(2)).to be_within(0.1).of(1.2)
+      end
+    end
+
+    context 'with max_delay' do
+      before do
+        retry_config.update!(max_delay: 0.5)
+      end
+
+      it 'returns capped delay seconds' do
+        expect(retry_config.delay_seconds(0)).to be_between(0, 0.3)
+        expect(retry_config.delay_seconds(1)).to be_between(0, 0.5)
+        expect(retry_config.delay_seconds(2)).to be_between(0, 0.5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Barbeque already has client-side retry feature
(BarbequeClient::Retryable), but when the job execution
(`rails barbeque:execute`) is interrupted before reaching the ActiveJob
codebase, Barbeque::Retryable cannot work. So I'd like to add
server-side retry feature.

----

![](https://gyazo.wanko.cc/36f343d8b5df873da7391a1881fd8a79.png)
![](https://gyazo.wanko.cc/736b4696c259ae49bed3416e865ce311.png)

@cookpad/infra please review