### PR TITLE
Coerce AS::Duration to Integer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
     - master
 rvm:
   - ruby-head
+  - 2.6.1
   - 2.5.3
   - 2.4.5
   - 2.3.8

--- a/app/models/barbeque/job_definition.rb
+++ b/app/models/barbeque/job_definition.rb
@@ -26,7 +26,7 @@ class Barbeque::JobDefinition < Barbeque::ApplicationRecord
         avg_time: avg_time,
       }
     end
-    (from.to_i ... to.to_i).step(1.hour).map do |t|
+    (from.to_i ... to.to_i).step(1.hour.to_i).map do |t|
       time = Time.at(t)
       stats[time].merge(date_hour: time)
     end


### PR DESCRIPTION
It fixes significant performance issue with Ruby 2.6 and Rails 5.2.
https://github.com/rails/rails/issues/34888

FYI @cookpad/infra 