### PR TITLE
Add notify_failure_only_if_retry_limit_reached option

### DIFF
--- a/app/controllers/barbeque/job_definitions_controller.rb
+++ b/app/controllers/barbeque/job_definitions_controller.rb
@@ -81,7 +81,7 @@ class Barbeque::JobDefinitionsController < Barbeque::ApplicationController
   private
 
   def slack_notification_params
-    %i[id channel notify_success failure_notification_text _destroy]
+    %i[id channel notify_success notify_failure_only_if_retry_limit_reached failure_notification_text _destroy]
   end
 
   def retry_config_params

--- a/app/views/barbeque/job_definitions/_slack_notification_field.html.haml
+++ b/app/views/barbeque/job_definitions/_slack_notification_field.html.haml
@@ -25,6 +25,9 @@
         .col-md-8
           = f.check_box :notify_success
           = f.label :notify_success, 'Notify success event to Slack'
+        .col-md-8
+          = f.check_box :notify_failure_only_if_retry_limit_reached
+          = f.label :notify_failure_only_if_retry_limit_reached, 'Notify failure event to Slack only if retry limit reached'
 
       .row
         .col-md-8

--- a/db/migrate/20190311034445_add_notify_failure_only_if_retry_limit_reached_to_barbeque_slack_notifications.rb
+++ b/db/migrate/20190311034445_add_notify_failure_only_if_retry_limit_reached_to_barbeque_slack_notifications.rb
@@ -1,0 +1,5 @@
+class AddNotifyFailureOnlyIfRetryLimitReachedToBarbequeSlackNotifications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :barbeque_slack_notifications, :notify_failure_only_if_retry_limit_reached, :boolean, default: false, null: false
+  end
+end

--- a/lib/barbeque/slack_notifier.rb
+++ b/lib/barbeque/slack_notifier.rb
@@ -82,7 +82,7 @@ module Barbeque
           return true
         end
 
-        job_execution_with_slack_notification.job_definition.retry_config.retry_limit == job_execution_with_slack_notification.job_retries.count
+        job_execution_with_slack_notification.job_definition.retry_config.retry_limit <= job_execution_with_slack_notification.job_retries.count
       end
     end
   end

--- a/spec/barbeque/executor/docker_spec.rb
+++ b/spec/barbeque/executor/docker_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Barbeque::Executor::Docker do
           end
 
           it 'performs retry' do
-          expect(Open3).to receive(:capture3).with('docker', 'logs', container_id).and_return([stdout, stderr, log_status])
+            expect(Open3).to receive(:capture3).with('docker', 'logs', container_id).and_return([stdout, stderr, log_status])
             expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(job_execution, stdout, stderr)
             expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
             expect(job_execution).to be_running

--- a/spec/barbeque/executor/docker_spec.rb
+++ b/spec/barbeque/executor/docker_spec.rb
@@ -452,7 +452,6 @@ RSpec.describe Barbeque::Executor::Docker do
               expect(Open3).to receive(:capture3).with('docker', 'logs', container_id).and_return([stdout, stderr, log_status])
               expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(job_retry, stdout, stderr)
               expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
-              expect(slack_client).to receive(:notify_failure).once
               executor.poll_retry(job_retry)
 
               Barbeque::DockerContainer.create!(message_id: job_retry2.message_id, container_id: container_id2)
@@ -461,6 +460,7 @@ RSpec.describe Barbeque::Executor::Docker do
               expect(Open3).to receive(:capture3).with('docker', 'inspect', container_id2) {
                 [JSON.dump([container_info]), '', inspect_status]
               }
+              expect(slack_client).to receive(:notify_failure).once
               executor.poll_retry(job_retry2)
             end
           end

--- a/spec/barbeque/executor/docker_spec.rb
+++ b/spec/barbeque/executor/docker_spec.rb
@@ -181,6 +181,44 @@ RSpec.describe Barbeque::Executor::Docker do
             expect(job_execution).to be_retried
           end
         end
+
+        context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: false)' do
+          let(:slack_client) { double('Barbeque::SlackClient') }
+          let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false) }
+
+          before do
+            job_execution.job_definition.update!(slack_notification: slack_notification)
+            allow(Barbeque::SlackClient).to receive(:new).with(slack_notification.channel).and_return(slack_client)
+            FactoryBot.create(:retry_config, job_definition: job_definition)
+          end
+
+          it 'sends slack notification' do
+            expect(Open3).to receive(:capture3).with('docker', 'logs', container_id).and_return([stdout, stderr, log_status])
+            expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(job_execution, stdout, stderr)
+            expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+            expect(slack_client).to receive(:notify_failure)
+            executor.poll_execution(job_execution)
+          end
+        end
+
+        context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: true)' do
+          let(:slack_client) { double('Barbeque::SlackClient') }
+          let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false, notify_failure_only_if_retry_limit_reached: true) }
+
+          before do
+            job_execution.job_definition.update!(slack_notification: slack_notification)
+            allow(Barbeque::SlackClient).to receive(:new).with(slack_notification.channel).and_return(slack_client)
+            FactoryBot.create(:retry_config, job_definition: job_definition)
+          end
+
+          it 'does not send slack notification' do
+            expect(Open3).to receive(:capture3).with('docker', 'logs', container_id).and_return([stdout, stderr, log_status])
+            expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(job_execution, stdout, stderr)
+            expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+            expect(slack_client).not_to receive(:notify_failure)
+            executor.poll_execution(job_execution)
+          end
+        end
       end
     end
   end
@@ -373,6 +411,59 @@ RSpec.describe Barbeque::Executor::Docker do
             job_execution.reload
             expect(job_retry).to be_failed
             expect(job_execution).to be_retried
+          end
+        end
+
+        context 'when retried job fails for retry limit of times' do
+          let(:slack_client) { double('Barbeque::SlackClient') }
+          let(:container_id2) { '40fa4fcb316f90f65d70717f66357e065747f8c216f392817bb8237f51dc416e' }
+          let(:job_retry2) { FactoryBot.create(:job_retry, job_execution: job_execution, status: :pending) }
+
+          before do
+            container_info['State']['ExitCode'] = 1
+            job_execution.job_definition.update!(slack_notification: slack_notification)
+            allow(Barbeque::SlackClient).to receive(:new).with(slack_notification.channel).and_return(slack_client)
+            FactoryBot.create(:retry_config, job_definition: job_definition, retry_limit: 2)
+          end
+
+          context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: false)' do
+            let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false ) }
+
+            it 'performs retry with sending slack notification for two times' do
+              expect(Open3).to receive(:capture3).with('docker', 'logs', container_id).and_return([stdout, stderr, log_status])
+              expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(job_retry, stdout, stderr)
+              expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+              expect(slack_client).to receive(:notify_failure).twice
+              executor.poll_retry(job_retry)
+
+              Barbeque::DockerContainer.create!(message_id: job_retry2.message_id, container_id: container_id2)
+              expect(Open3).to receive(:capture3).with('docker', 'logs', container_id2).and_return([stdout, stderr, log_status])
+              expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(job_retry2, stdout, stderr)
+              expect(Open3).to receive(:capture3).with('docker', 'inspect', container_id2) {
+                [JSON.dump([container_info]), '', inspect_status]
+              }
+              executor.poll_retry(job_retry2)
+            end
+          end
+
+          context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: true)' do
+            let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false, notify_failure_only_if_retry_limit_reached: true) }
+
+            it 'performs retry with sending only one slack notification' do
+              expect(Open3).to receive(:capture3).with('docker', 'logs', container_id).and_return([stdout, stderr, log_status])
+              expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(job_retry, stdout, stderr)
+              expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+              expect(slack_client).to receive(:notify_failure).once
+              executor.poll_retry(job_retry)
+
+              Barbeque::DockerContainer.create!(message_id: job_retry2.message_id, container_id: container_id2)
+              expect(Open3).to receive(:capture3).with('docker', 'logs', container_id2).and_return([stdout, stderr, log_status])
+              expect(Barbeque::ExecutionLog).to receive(:save_stdout_and_stderr).with(job_retry2, stdout, stderr)
+              expect(Open3).to receive(:capture3).with('docker', 'inspect', container_id2) {
+                [JSON.dump([container_info]), '', inspect_status]
+              }
+              executor.poll_retry(job_retry2)
+            end
           end
         end
       end

--- a/spec/barbeque/executor/docker_spec.rb
+++ b/spec/barbeque/executor/docker_spec.rb
@@ -420,7 +420,6 @@ RSpec.describe Barbeque::Executor::Docker do
           let(:job_retry2) { FactoryBot.create(:job_retry, job_execution: job_execution, status: :pending) }
 
           before do
-            container_info['State']['ExitCode'] = 1
             job_execution.job_definition.update!(slack_notification: slack_notification)
             allow(Barbeque::SlackClient).to receive(:new).with(slack_notification.channel).and_return(slack_client)
             FactoryBot.create(:retry_config, job_definition: job_definition, retry_limit: 2)

--- a/spec/barbeque/executor/hako_spec.rb
+++ b/spec/barbeque/executor/hako_spec.rb
@@ -227,6 +227,42 @@ describe Barbeque::Executor::Hako do
             expect(job_execution).to be_retried
           end
         end
+
+        context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: false)' do
+          let(:slack_client) { double('Barbeque::SlackClient') }
+          let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false) }
+
+          before do
+            job_execution.job_definition.update!(slack_notification: slack_notification)
+            allow(Barbeque::SlackClient).to receive(:new).with(slack_notification.channel).and_return(slack_client)
+            FactoryBot.create(:retry_config, job_definition: job_definition)
+          end
+
+          it 'sends slack notification' do
+            expect(job_execution).to be_running
+            expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+            expect(slack_client).to receive(:notify_failure)
+            executor.poll_execution(job_execution)
+          end
+        end
+
+        context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: true)' do
+          let(:slack_client) { double('Barbeque::SlackClient') }
+          let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false, notify_failure_only_if_retry_limit_reached: true) }
+
+          before do
+            job_execution.job_definition.update!(slack_notification: slack_notification)
+            allow(Barbeque::SlackClient).to receive(:new).with(slack_notification.channel).and_return(slack_client)
+            FactoryBot.create(:retry_config, job_definition: job_definition)
+          end
+
+          it 'does not send slack notification' do
+            expect(job_execution).to be_running
+            expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+            expect(slack_client).not_to receive(:notify_failure)
+            executor.poll_execution(job_execution)
+          end
+        end
       end
     end
   end
@@ -415,6 +451,48 @@ describe Barbeque::Executor::Hako do
             job_execution.reload
             expect(job_retry).to be_failed
             expect(job_execution).to be_retried
+          end
+        end
+      end
+
+      context 'when retried job fails for retry limit of times' do
+        let(:slack_client) { double('Barbeque::SlackClient') }
+        let(:task_arn2) { 'arn:aws:ecs:ap-northeast-1:123456789012:task/01234567-89ab-cdef-0123-456789abcdef' }
+        let(:job_retry2) { FactoryBot.create(:job_retry, job_execution: job_execution, status: :pending) }
+
+        before do
+          stopped_info['detail']['containers'][0]['exitCode'] = 1
+          job_execution.job_definition.update!(slack_notification: slack_notification)
+          allow(Barbeque::SlackClient).to receive(:new).with(slack_notification.channel).and_return(slack_client)
+          allow(executor.hako_s3_client).to receive(:get_stopped_result).and_return(
+            Aws::Json::Parser.new(Aws::ECS::Client.api.operation('describe_tasks').output.shape.member(:tasks).shape.member).parse(JSON.dump(stopped_info["detail"]))
+          )
+          FactoryBot.create(:retry_config, job_definition: job_definition, retry_limit: 2)
+        end
+
+        context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: false)' do
+          let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false ) }
+
+          it 'performs retry with sending slack notification for two times' do
+            expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+            expect(slack_client).to receive(:notify_failure).twice
+            executor.poll_retry(job_retry)
+
+            Barbeque::EcsHakoTask.create!(message_id: job_retry2.message_id, cluster: 'barbeque', task_arn: task_arn2)
+            executor.poll_retry(job_retry)
+          end
+        end
+
+        context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: true)' do
+          let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false, notify_failure_only_if_retry_limit_reached: true) }
+
+          it 'performs retry with sending only one slack notification' do
+            expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+            expect(slack_client).to receive(:notify_failure).once
+            executor.poll_retry(job_retry)
+
+            Barbeque::EcsHakoTask.create!(message_id: job_retry2.message_id, cluster: 'barbeque', task_arn: task_arn2)
+            executor.poll_retry(job_retry)
           end
         end
       end

--- a/spec/barbeque/executor/hako_spec.rb
+++ b/spec/barbeque/executor/hako_spec.rb
@@ -453,46 +453,45 @@ describe Barbeque::Executor::Hako do
             expect(job_execution).to be_retried
           end
         end
-      end
 
-      context 'when retried job fails for retry limit of times' do
-        let(:slack_client) { double('Barbeque::SlackClient') }
-        let(:task_arn2) { 'arn:aws:ecs:ap-northeast-1:123456789012:task/01234567-89ab-cdef-0123-456789abcdef' }
-        let(:job_retry2) { FactoryBot.create(:job_retry, job_execution: job_execution, status: :pending) }
+        context 'when retried job fails for retry limit of times' do
+          let(:slack_client) { double('Barbeque::SlackClient') }
+          let(:task_arn2) { 'arn:aws:ecs:ap-northeast-1:123456789012:task/01234567-89ab-cdef-0123-456789abcdef' }
+          let(:job_retry2) { FactoryBot.create(:job_retry, job_execution: job_execution, status: :pending) }
 
-        before do
-          stopped_info['detail']['containers'][0]['exitCode'] = 1
-          job_execution.job_definition.update!(slack_notification: slack_notification)
-          allow(Barbeque::SlackClient).to receive(:new).with(slack_notification.channel).and_return(slack_client)
-          allow(executor.hako_s3_client).to receive(:get_stopped_result).and_return(
-            Aws::Json::Parser.new(Aws::ECS::Client.api.operation('describe_tasks').output.shape.member(:tasks).shape.member).parse(JSON.dump(stopped_info["detail"]))
-          )
-          FactoryBot.create(:retry_config, job_definition: job_definition, retry_limit: 2)
-        end
-
-        context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: false)' do
-          let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false ) }
-
-          it 'performs retry with sending slack notification for two times' do
-            expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
-            expect(slack_client).to receive(:notify_failure).twice
-            executor.poll_retry(job_retry)
-
-            Barbeque::EcsHakoTask.create!(message_id: job_retry2.message_id, cluster: 'barbeque', task_arn: task_arn2)
-            executor.poll_retry(job_retry)
+          before do
+            job_execution.job_definition.update!(slack_notification: slack_notification)
+            allow(Barbeque::SlackClient).to receive(:new).with(slack_notification.channel).and_return(slack_client)
+            allow(executor.hako_s3_client).to receive(:get_stopped_result).and_return(
+              Aws::Json::Parser.new(Aws::ECS::Client.api.operation('describe_tasks').output.shape.member(:tasks).shape.member).parse(JSON.dump(stopped_info["detail"]))
+            )
+            FactoryBot.create(:retry_config, job_definition: job_definition, retry_limit: 2)
           end
-        end
 
-        context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: true)' do
-          let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false, notify_failure_only_if_retry_limit_reached: true) }
+          context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: false)' do
+            let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false ) }
 
-          it 'performs retry with sending only one slack notification' do
-            expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
-            expect(slack_client).to receive(:notify_failure).once
-            executor.poll_retry(job_retry)
+            it 'performs retry with sending slack notification for two times' do
+              expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+              expect(slack_client).to receive(:notify_failure).twice
+              executor.poll_retry(job_retry)
 
-            Barbeque::EcsHakoTask.create!(message_id: job_retry2.message_id, cluster: 'barbeque', task_arn: task_arn2)
-            executor.poll_retry(job_retry)
+              Barbeque::EcsHakoTask.create!(message_id: job_retry2.message_id, cluster: 'barbeque', task_arn: task_arn2)
+              executor.poll_retry(job_retry)
+            end
+          end
+
+          context 'with retry_config and slack_notification (notify_failure_only_if_retry_limit_reached: true)' do
+            let(:slack_notification) { FactoryBot.create(:slack_notification, notify_success: false, notify_failure_only_if_retry_limit_reached: true) }
+
+            it 'performs retry with sending only one slack notification' do
+              expect(Barbeque::MessageRetryingService.sqs_client).to receive(:send_message).with(queue_url: a_kind_of(String), message_body: a_kind_of(String), delay_seconds: a_kind_of(Integer))
+              expect(slack_client).to receive(:notify_failure).once
+              executor.poll_retry(job_retry)
+
+              Barbeque::EcsHakoTask.create!(message_id: job_retry2.message_id, cluster: 'barbeque', task_arn: task_arn2)
+              executor.poll_retry(job_retry)
+            end
           end
         end
       end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_21_050714) do
+ActiveRecord::Schema.define(version: 2019_03_11_034445) do
 
   create_table "barbeque_apps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2019_02_21_050714) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["message_id"], name: "index_barbeque_job_retries_on_message_id", unique: true
+    t.index ["status"], name: "index_barbeque_job_retries_on_status"
   end
 
   create_table "barbeque_retry_configs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
@@ -99,6 +100,7 @@ ActiveRecord::Schema.define(version: 2019_02_21_050714) do
     t.string "failure_notification_text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "notify_failure_only_if_retry_limit_reached", default: false, null: false
   end
 
   create_table "barbeque_sns_subscriptions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -107,7 +109,6 @@ ActiveRecord::Schema.define(version: 2019_02_21_050714) do
     t.integer "job_definition_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["topic_arn"], name: "index_barbeque_sns_subscriptions_on_topic_arn", unique: true
   end
 
 end


### PR DESCRIPTION
A server-side retry feature was introduced in https://github.com/cookpad/barbeque/pull/75. This feature allows us to reduce some efforts for job management, however, multiple failure notifications would be still sent to Slack even if retry succeeded (of course when Slack notification and retry configurations are both enabled).

I would like to introduce an option for limiting failure notification `notify_failure_only_if_retry_limit_reached`.  If this option is enabled, we can receive only one Slack notification when the retry limit is reached, which means all retry is failed. One of the downsides of this is that the behavior about retry and notification would be incompatible in an environment that client-side retry and server-side retry are both used.

![Screen Shot 2019-03-11 at 16 13 56](https://user-images.githubusercontent.com/8341422/54111729-ecdf9600-4427-11e9-9d5e-b1df0e5f2fa4.png)

@cookpad/infra WDYT? If you think this seems good, I will add some specs later on.