### PR TITLE
Change default base_delay to 15 seconds

### DIFF
--- a/db/migrate/20190315052951_change_barbeque_retry_configs_base_delay_default_value.rb
+++ b/db/migrate/20190315052951_change_barbeque_retry_configs_base_delay_default_value.rb
@@ -1,0 +1,9 @@
+class ChangeBarbequeRetryConfigsBaseDelayDefaultValue < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :barbeque_retry_configs, :base_delay, 15
+  end
+
+  def down
+    change_column_default :barbeque_retry_configs, :base_delay, 0.3
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_11_034445) do
+ActiveRecord::Schema.define(version: 2019_03_15_052951) do
 
   create_table "barbeque_apps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 2019_03_11_034445) do
   create_table "barbeque_retry_configs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "job_definition_id", null: false
     t.integer "retry_limit", default: 3, null: false
-    t.float "base_delay", default: 0.3, null: false
+    t.float "base_delay", default: 15.0, null: false
     t.integer "max_delay"
     t.boolean "jitter", default: true, null: false
     t.datetime "created_at", null: false

--- a/spec/models/barbeque/retry_config_spec.rb
+++ b/spec/models/barbeque/retry_config_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Barbeque::RetryConfig do
 
   describe '#delay_seconds' do
     it 'returns delay seconds with jitter by default' do
-      expect(retry_config.delay_seconds(0)).to be_between(0, 0.3)
-      expect(retry_config.delay_seconds(1)).to be_between(0, 0.6)
-      expect(retry_config.delay_seconds(2)).to be_between(0, 1.2)
+      expect(retry_config.delay_seconds(0)).to be_between(0, 15)
+      expect(retry_config.delay_seconds(1)).to be_between(0, 30)
+      expect(retry_config.delay_seconds(2)).to be_between(0, 60)
     end
 
     context 'without jitter' do
@@ -17,21 +17,21 @@ RSpec.describe Barbeque::RetryConfig do
       end
 
       it 'returns delay seconds without randomness' do
-        expect(retry_config.delay_seconds(0)).to be_within(0.1).of(0.3)
-        expect(retry_config.delay_seconds(1)).to be_within(0.1).of(0.6)
-        expect(retry_config.delay_seconds(2)).to be_within(0.1).of(1.2)
+        expect(retry_config.delay_seconds(0)).to be_within(0.1).of(15)
+        expect(retry_config.delay_seconds(1)).to be_within(0.1).of(30)
+        expect(retry_config.delay_seconds(2)).to be_within(0.1).of(60)
       end
     end
 
     context 'with max_delay' do
       before do
-        retry_config.update!(max_delay: 0.5)
+        retry_config.update!(max_delay: 20)
       end
 
       it 'returns capped delay seconds' do
-        expect(retry_config.delay_seconds(0)).to be_between(0, 0.3)
-        expect(retry_config.delay_seconds(1)).to be_between(0, 0.5)
-        expect(retry_config.delay_seconds(2)).to be_between(0, 0.5)
+        expect(retry_config.delay_seconds(0)).to be_between(0, 15)
+        expect(retry_config.delay_seconds(1)).to be_between(0, 20)
+        expect(retry_config.delay_seconds(2)).to be_between(0, 20)
       end
     end
   end


### PR DESCRIPTION
0.3 seconds looks a good default value for online transactions but too
fast for retrying offline batch jobs, I think.

@cookpad/infra what do you think?