### PR TITLE
Count running job_retries only

### DIFF
--- a/lib/barbeque/runner.rb
+++ b/lib/barbeque/runner.rb
@@ -43,7 +43,7 @@ module Barbeque
       end
 
       loop do
-        current_num = @job_queue.job_executions.where(status: [:running, :retried]).count
+        current_num = @job_queue.job_executions.where(status: :running).count + Barbeque::JobRetry.where(status: :running).joins(job_execution: :job_queue).merge(Barbeque::JobQueue.where(id: @job_queue.id)).count
         if current_num < max_num
           return
         end

--- a/spec/barbeque/runner_spec.rb
+++ b/spec/barbeque/runner_spec.rb
@@ -47,7 +47,9 @@ RSpec.describe Barbeque::Runner do
             2.times do
               FactoryBot.create(:job_execution, status: :running, job_queue: job_queue)
             end
-            FactoryBot.create(:job_execution, status: :retried, job_queue: job_queue)
+            retried_executions = 2.times.map { FactoryBot.create(:job_execution, status: :retried, job_queue: job_queue) }
+            # One retried execution is already running
+            FactoryBot.create(:job_retry, status: :running, job_execution: retried_executions[0])
           end
 
           it 'waits' do


### PR DESCRIPTION
When checking maximum_concurrent_executions, "retried but not running"
executions should not be counted.

@cookpad/infra please review