### PR TITLE
Change job name to case-sensitive

### DIFF
--- a/db/migrate/20191029105530_change_job_name_to_case_sensitive.rb
+++ b/db/migrate/20191029105530_change_job_name_to_case_sensitive.rb
@@ -1,0 +1,9 @@
+class ChangeJobNameToCaseSensitive < ActiveRecord::Migration[5.2]
+  def up
+    change_column :barbeque_job_definitions, :job, :string, collation: 'utf8mb4_bin'
+  end
+
+  def down
+    change_column :barbeque_job_definitions, :job, :string, collation: nil
+  end
+end

--- a/spec/controllers/barbeque/job_definitions_controller_spec.rb
+++ b/spec/controllers/barbeque/job_definitions_controller_spec.rb
@@ -111,6 +111,16 @@ describe Barbeque::JobDefinitionsController do
         }.to_not change(Barbeque::JobDefinition, :count)
       end
     end
+
+    it 'treats job name as case-sensitive' do
+      expect {
+        post :create, params: { job_definition: attributes }
+      }.to change(Barbeque::JobDefinition, :count).by(1)
+      attributes[:job].downcase!
+      expect {
+        post :create, params: { job_definition: attributes }
+      }.to change(Barbeque::JobDefinition, :count).by(1)
+    end
   end
 
   describe '#update' do

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_15_052951) do
+ActiveRecord::Schema.define(version: 2019_10_29_105530) do
 
   create_table "barbeque_apps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2019_03_15_052951) do
   end
 
   create_table "barbeque_job_definitions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
-    t.string "job", null: false
+    t.string "job", null: false, collation: "utf8mb4_bin"
     t.integer "app_id", null: false
     t.string "command", null: false
     t.text "description"


### PR DESCRIPTION
Since the job name is passed to launched job process as identifier, job
name should be case-sensitive. The job name is also used as class name
in ActiveJob adapter.
https://github.com/cookpad/barbeque_client/blob/v0.10.1/lib/barbeque_client/executor.rb#L18

@cookpad/infra please review