### PR TITLE
Delete duplicated message

### DIFF
--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -52,6 +52,9 @@ module Barbeque
           end
         end
       rescue ActiveRecord::RecordNotUnique => e
+        # There's a case where Barbeque receives message which was already received or deleted.
+        # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html
+        @message_queue.delete_message(@message)
         raise DuplicatedExecution.new(e.message)
       end
     end

--- a/spec/barbeque/message_handler/job_execution_spec.rb
+++ b/spec/barbeque/message_handler/job_execution_spec.rb
@@ -63,6 +63,7 @@ describe Barbeque::MessageHandler::JobExecution do
       end
 
       it 'raises DuplicatedExecution' do
+        expect(message_queue).to receive(:delete_message).with(message)
         expect { handler.run }.to raise_error(Barbeque::MessageHandler::DuplicatedExecution)
       end
     end


### PR DESCRIPTION
The documentation of standard queue says there's a case where
DeleteMessage fails to delete a copy of the message.
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html
In this case, Barbeque has to delete the same message multiple times.

@cookpad/infra please review