### PR TITLE
Update tested Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ branches:
     - master
 rvm:
   - ruby-head
-  - 2.6.1
-  - 2.5.3
-  - 2.4.5
-  - 2.3.8
+  - 2.6.6
+  - 2.5.8
+  - 2.4.10
 script:
   # To resolve: Mysql2::Error: Specified key was too long; max key length is 767 bytes
   - echo '[mysqld]' | sudo sh -c 'cat >>  /etc/mysql/my.cnf'


### PR DESCRIPTION
2.3 is already EOL https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/