### PR TITLE
Pass `BARBEQUE_SENT_TIMESTAMP` variable to invoked jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.x.x (xxxx-xx-xx)
+### New features
+- Pass `BARBEQUE_SENT_TIMESTAMP` variable to invoked jobs
+  - The value is epoch time in milliseconds when the message is sent to the queue. See also: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html
+
 ## v2.7.5 (2020-05-29)
 ### Bug fixes
 - Use kaminari helper to generate links safely

--- a/lib/barbeque/message/base.rb
+++ b/lib/barbeque/message/base.rb
@@ -5,6 +5,7 @@ module Barbeque
       attr_reader :id             # [String] Barbeque::JobExecution is associated via `message_id`
       attr_reader :receipt_handle # [String] Used to ack a message
       attr_reader :type           # [String] "JobExecution", "JobRetry", etc
+      attr_reader :sent_timestamp # [String] The time the message was sent to the queue (epoch time in milliseconds)
 
       # @param [Aws::SQS::Types::Message] raw_message
       # @param message_body [Hash] parse result of `raw_message.body`
@@ -12,6 +13,7 @@ module Barbeque
         assign_body(message_body)
         @id             = raw_message.message_id
         @receipt_handle = raw_message.receipt_handle
+        @sent_timestamp = raw_message.attributes['SentTimestamp']
       end
 
       # To distinguish with `Barbeque::Message::InvalidMessage`

--- a/lib/barbeque/message_handler/job_execution.rb
+++ b/lib/barbeque/message_handler/job_execution.rb
@@ -34,6 +34,7 @@ module Barbeque
           'BARBEQUE_MESSAGE_ID'  => @message.id,
           'BARBEQUE_QUEUE_NAME'  => @message_queue.job_queue.name,
           'BARBEQUE_RETRY_COUNT' => '0',
+          'BARBEQUE_SENT_TIMESTAMP' => @message.sent_timestamp,
         }
       end
 

--- a/lib/barbeque/message_handler/job_retry.rb
+++ b/lib/barbeque/message_handler/job_retry.rb
@@ -45,6 +45,7 @@ module Barbeque
           'BARBEQUE_MESSAGE_ID'  => @message.retry_message_id,
           'BARBEQUE_QUEUE_NAME'  => @message_queue.job_queue.name,
           'BARBEQUE_RETRY_COUNT' => job_execution.job_retries.count.to_s,
+          'BARBEQUE_SENT_TIMESTAMP' => @message.sent_timestamp,
         }
       end
 

--- a/lib/barbeque/message_queue.rb
+++ b/lib/barbeque/message_queue.rb
@@ -48,6 +48,7 @@ module Barbeque
         queue_url: @job_queue.queue_url,
         wait_time_seconds: Barbeque.config.sqs_receive_message_wait_time,
         max_number_of_messages: 1,
+        attribute_names: ['SentTimestamp'],
       )
       if result.messages[0]
         Barbeque::Message.parse(result.messages[0])

--- a/spec/barbeque/message_handler/job_execution_spec.rb
+++ b/spec/barbeque/message_handler/job_execution_spec.rb
@@ -9,7 +9,7 @@ describe Barbeque::MessageHandler::JobExecution do
     let(:message_queue) { Barbeque::MessageQueue.new(job_queue) }
     let(:message) do
       Barbeque::Message::JobExecution.new(
-        Aws::SQS::Types::Message.new(message_id: SecureRandom.uuid, receipt_handle: 'dummy receipt handle'),
+        Aws::SQS::Types::Message.new(message_id: SecureRandom.uuid, receipt_handle: 'dummy receipt handle', attributes: { 'SentTimestamp' => '1638514604302' }),
         {
           'Application' => job_definition.app.name,
           'Job'         => job_definition.job,
@@ -51,6 +51,7 @@ describe Barbeque::MessageHandler::JobExecution do
           'BARBEQUE_MESSAGE_ID'  => message.id,
           'BARBEQUE_QUEUE_NAME'  => job_queue.name,
           'BARBEQUE_RETRY_COUNT' => '0',
+          'BARBEQUE_SENT_TIMESTAMP' => '1638514604302',
         )
       }
       expect(message_queue).to receive(:delete_message).with(message)

--- a/spec/barbeque/message_handler/job_retry_spec.rb
+++ b/spec/barbeque/message_handler/job_retry_spec.rb
@@ -10,7 +10,7 @@ describe Barbeque::MessageHandler::JobRetry do
     let(:job_execution) { create(:job_execution, status: :failed, job_definition: job_definition, job_queue: job_queue) }
     let(:message) do
       Barbeque::Message::JobRetry.new(
-        Aws::SQS::Types::Message.new(message_id: SecureRandom.uuid, receipt_handle: 'dummy receipt handle'),
+        Aws::SQS::Types::Message.new(message_id: SecureRandom.uuid, receipt_handle: 'dummy receipt handle', attributes: { 'SentTimestamp' => '1638514604302' }),
         { "RetryMessageId" => job_execution.message_id },
       )
     end
@@ -40,6 +40,7 @@ describe Barbeque::MessageHandler::JobRetry do
           'BARBEQUE_MESSAGE_ID'  => job_execution.message_id,
           'BARBEQUE_QUEUE_NAME'  => job_queue.name,
           'BARBEQUE_RETRY_COUNT' => '1',
+          'BARBEQUE_SENT_TIMESTAMP' => '1638514604302',
         )
       }
       expect(message_queue).to receive(:delete_message).with(message)

--- a/spec/barbeque/message_handler/notification_spec.rb
+++ b/spec/barbeque/message_handler/notification_spec.rb
@@ -6,7 +6,7 @@ describe Barbeque::MessageHandler::Notification do
     let(:sns_subscription) { create(:sns_subscription) }
     let(:message) do
       Barbeque::Message::Notification.new(
-        Aws::SQS::Types::Message.new(message_id: SecureRandom.uuid, receipt_handle: 'dummy receipt handle'),
+        Aws::SQS::Types::Message.new(message_id: SecureRandom.uuid, receipt_handle: 'dummy receipt handle', attributes: { 'SentTimestamp' => '1638514604302' }),
         {
           'TopicArn'  => sns_subscription.topic_arn,
           'Message'   => ['hello'].to_json,

--- a/spec/barbeque/message_queue_spec.rb
+++ b/spec/barbeque/message_queue_spec.rb
@@ -16,6 +16,7 @@ describe Barbeque::MessageQueue do
         message_id: message_id,
         receipt_handle: receipt_handle,
         body: { 'Type' => type, 'Job' => job }.to_json,
+        attributes: { 'SentTimestamp' => '1638514604302' },
       )
     end
     let(:message) { Barbeque::Message.parse(raw_message) }

--- a/spec/barbeque/message_spec.rb
+++ b/spec/barbeque/message_spec.rb
@@ -21,7 +21,12 @@ describe Barbeque::Message::Base do
     }.to_json
   end
   let(:sqs_message) do
-    double('Aws::SQS::Types::Message', body: raw_sqs_message, message_id: message_id, receipt_handle: receipt_handle)
+    Aws::SQS::Types::Message.new(
+      body: raw_sqs_message,
+      message_id: message_id,
+      receipt_handle: receipt_handle,
+      attributes: { 'SentTimestamp' => '1638514604302' },
+    )
   end
 
   context 'given JobExecution' do

--- a/spec/barbeque/runner_spec.rb
+++ b/spec/barbeque/runner_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Barbeque::Runner do
       'Message' => { 'FOO' => 'BAR' },
     )
   end
-  let(:sqs_message) { Aws::SQS::Types::Message.new(body: message_body) }
+  let(:sqs_message) { Aws::SQS::Types::Message.new(body: message_body, attributes: { 'SentTimestamp' => '1638514604302' }) }
   let(:message) { Barbeque::Message.parse(sqs_message) }
   let(:message_queue) { double('Barbeque::MessageQueue', job_queue: 'default') }
   let(:handler) { double('Barbeque::MessageHandler') }


### PR DESCRIPTION
The value is epoch time in milliseconds when the message is sent to the
queue.
See also: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html

cc @cookpad/infra @nekketsuuu 