### PR TITLE
Support sentry-ruby in exception handlers by implementing Barbeque::ExceptionHandler::Sentry

### DIFF
--- a/lib/barbeque/exception_handler.rb
+++ b/lib/barbeque/exception_handler.rb
@@ -51,5 +51,32 @@ module Barbeque
         ::Raven.capture_exception(e)
       end
     end
+
+    class Sentry
+      def initialize
+        ::Sentry.get_current_hub.push_scope
+      end
+
+      def clear_context
+        ::Sentry.get_current_hub.pop_scope
+        ::Sentry.get_current_hub.push_scope
+      end
+
+      # @param [String] message_id
+      # @param [String, nil] message_type
+      def set_message_context(message_id, message_type)
+        ::Sentry.configure_scope do |scope|
+          scope.set_tags(
+            message_id: message_id,
+            message_type: message_type
+          )
+        end
+      end
+
+      # @param [Exception] e
+      def handle_exception(e)
+        ::Sentry.capture_exception(e)
+      end
+    end
   end
 end


### PR DESCRIPTION
Support `sentry-ruby` gem which is the successor of `sentry-raven` gem, implemented as an ExceptionHandler.
Unlike `sentry-raven`, we need to handle scope manually in order to destroy the context.

ExceptionHandler is cleared context after each message is processed. 
Therefore, I decided to re-create the scope at initialization and at when calling clear_context.
https://github.com/cookpad/barbeque/blob/5de51f10ce1b195054f16fdb042f4fdf2db93d47/lib/barbeque/worker.rb#L51-L61

@cookpad/infra Please review.