### PR TITLE
Run tests with mysql:8.0 and drop support for Ruby < 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.6'
-          - '2.7'
           - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
     name: Run test with Ruby ${{ matrix.ruby }}
     services:
       mysql:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Run test with Ruby ${{ matrix.ruby }}
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: barbeque_root
           MYSQL_USER: barbeque

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Update Rails to 6.1
   - For Zeitwerk, Barbeque::SNSSubscription and Barbeque::SNSSubscriptionService are renamed to Barbeque::SnsSubscription and Barbeque::SnsSubscriptionService respectively
 - Support Ruby 3.0
+- Drop support for MySQL 5.7
 
 ## v2.8.0 (2021-12-23)
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Update Rails to 6.1
   - For Zeitwerk, Barbeque::SNSSubscription and Barbeque::SNSSubscriptionService are renamed to Barbeque::SnsSubscription and Barbeque::SnsSubscriptionService respectively
 - Support Ruby 3.0
+  - Drop support for Ruby < 3.0
 - Drop support for MySQL 5.7
 
 ## v2.8.0 (2021-12-23)

--- a/spec/barbeque/executor_spec.rb
+++ b/spec/barbeque/executor_spec.rb
@@ -12,12 +12,7 @@ describe Barbeque::Executor do
       let(:barbeque_yml) { 'barbeque' }
 
       it 'initializes a configured executor' do
-        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
-          # Ruby < 2.7 isn't ready for keyword arguments
-          expect(Barbeque::Executor::Docker).to receive(:new).with({})
-        else
-          expect(Barbeque::Executor::Docker).to receive(:new).with(no_args)
-        end
+        expect(Barbeque::Executor::Docker).to receive(:new).with(no_args)
         Barbeque::Executor.create
       end
     end


### PR DESCRIPTION
We're going to upgrade our Barbeque deployment to use MySQL 8.0-compatible database cluster. This PR updates MySQL version used in CI to prepare for that. I confirmed specs passing locally with MySQL 8.0.

@cookpad/infra could you please review?