### PR TITLE
feat: Cross-region SNS subscription

### DIFF
--- a/app/controllers/barbeque/sns_subscriptions_controller.rb
+++ b/app/controllers/barbeque/sns_subscriptions_controller.rb
@@ -8,7 +8,6 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
   end
 
   def new
-    @sns_topic_arns = fetch_sns_topic_arns
     @sns_subscription = Barbeque::SnsSubscription.new
   end
 
@@ -21,7 +20,6 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
     if Barbeque::SnsSubscriptionService.new.subscribe(@sns_subscription)
       redirect_to @sns_subscription, notice: 'SNS subscription was successfully created.'
     else
-      @sns_topic_arns = fetch_sns_topic_arns
       render :new
     end
   end
@@ -39,11 +37,5 @@ class Barbeque::SnsSubscriptionsController < Barbeque::ApplicationController
     sns_subscription = Barbeque::SnsSubscription.find(params[:id])
     Barbeque::SnsSubscriptionService.new.unsubscribe(sns_subscription)
     redirect_to sns_subscriptions_path, notice: 'SNS subscription was successfully destroyed.'
-  end
-
-  private
-
-  def fetch_sns_topic_arns
-    Barbeque::SnsSubscriptionService.sns_client.list_topics.flat_map(&:topics).map(&:topic_arn)
   end
 end

--- a/app/models/barbeque/sns_subscription.rb
+++ b/app/models/barbeque/sns_subscription.rb
@@ -7,5 +7,18 @@ module Barbeque
     validates :topic_arn,
       uniqueness: { scope: :job_queue, message: 'should be set with only one queue' },
       presence: true
+    validate :topic_arn_is_formatted
+
+    def topic_region
+      Aws::ARNParser.parse(topic_arn).region
+    end
+
+    private
+
+    def topic_arn_is_formatted
+      unless Aws::ARNParser.arn?(topic_arn)
+        errors.add(:topic_arn, 'is not a valid ARN')
+      end
+    end
   end
 end

--- a/app/services/barbeque/sns_subscription_service.rb
+++ b/app/services/barbeque/sns_subscription_service.rb
@@ -6,8 +6,10 @@ class Barbeque::SnsSubscriptionService
     @sqs_client ||= Aws::SQS::Client.new
   end
 
-  def self.sns_client
-    @sns_client ||= Aws::SNS::Client.new
+  def self.sns_client(region:)
+    return @sns_client[region] if @sns_client
+    @sns_client = Hash.new { |hash, region| hash[region] = Aws::SNS::Client.new(region: region) }
+    @sns_client[region]
   end
 
   # @param [Barbeque::SnsSubscription] sns_subscription
@@ -45,8 +47,8 @@ class Barbeque::SnsSubscriptionService
     Barbeque::SnsSubscriptionService.sqs_client
   end
 
-  def sns_client
-    Barbeque::SnsSubscriptionService.sns_client
+  def sns_client(region:)
+    Barbeque::SnsSubscriptionService.sns_client(region: region)
   end
 
   # @param [Barbeque::SnsSubscription] sns_subscription
@@ -98,7 +100,7 @@ class Barbeque::SnsSubscriptionService
     )
     queue_arn = sqs_attrs.attributes['QueueArn']
 
-    sns_client.subscribe(
+    sns_client(region: sns_subscription.topic_region).subscribe(
       topic_arn: sns_subscription.topic_arn,
       protocol: 'sqs',
       endpoint: queue_arn
@@ -112,14 +114,15 @@ class Barbeque::SnsSubscriptionService
       attribute_names: ['QueueArn'],
     )
     queue_arn = sqs_attrs.attributes['QueueArn']
+    region = sns_subscription.topic_region
 
-    subscriptions = sns_client.list_subscriptions_by_topic(
+    subscriptions = sns_client(region: region).list_subscriptions_by_topic(
       topic_arn: sns_subscription.topic_arn,
     )
     subscription_arn = subscriptions.subscriptions.find {|subscription| subscription.endpoint == queue_arn }.try!(:subscription_arn)
 
     if subscription_arn
-      sns_client.unsubscribe(
+      sns_client(region: region).unsubscribe(
         subscription_arn: subscription_arn,
       )
     end

--- a/app/views/barbeque/sns_subscriptions/_form.html.haml
+++ b/app/views/barbeque/sns_subscriptions/_form.html.haml
@@ -17,8 +17,7 @@
           - if @sns_subscription.persisted?
             .sns_subscription_topic_arn= @sns_subscription.topic_arn
           - else
-            = f.collection_select :topic_arn, @sns_topic_arns.map {|t| [t] }, :first, :first,
-              { prompt: true }, class: 'form-control'
+            = f.text_field :topic_arn, class: 'form-control'
 
       .row.form-group
         .col-md-4

--- a/spec/controllers/barbeque/job_definitions_controller_spec.rb
+++ b/spec/controllers/barbeque/job_definitions_controller_spec.rb
@@ -201,7 +201,7 @@ describe Barbeque::JobDefinitionsController do
       let(:subscription_arn) { 'arn:aws:sns:ap-northeast-1:012345678912:barbeque-spec:01234567-89ab-cdef-0123-456789abcdef' }
 
       before do
-        allow(Barbeque::SnsSubscriptionService).to receive(:sns_client).and_return(sns_client)
+        allow(Barbeque::SnsSubscriptionService).to receive(:sns_client).with(region: 'ap-northest-1').and_return(sns_client)
         allow(Barbeque::SnsSubscriptionService).to receive(:sqs_client).and_return(sqs_client)
 
         allow(sqs_client).to receive(:get_queue_attributes).

--- a/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
+++ b/spec/controllers/barbeque/sns_subscriptions_controller_spec.rb
@@ -62,7 +62,6 @@ describe Barbeque::SnsSubscriptionsController do
       it 'does not create a record and shows error message' do
         expect(sqs_client).to receive(:get_queue_attributes).with(queue_url: job_queue.queue_url, attribute_names: ['QueueArn'])
         expect(sns_client).to receive(:subscribe).and_raise(Aws::SNS::Errors::NotFound.new(self, 'not found'))
-        allow(controller).to receive(:fetch_sns_topic_arns).and_return([])
         post :create , params: { sns_subscription: attributes }
         expect(response).to render_template(:new)
         expect(assigns(:sns_subscription).errors[:topic_arn]).to eq(['is not found'])
@@ -73,7 +72,6 @@ describe Barbeque::SnsSubscriptionsController do
       it 'does not create a record and shows error message' do
         expect(sqs_client).to receive(:get_queue_attributes).with(queue_url: job_queue.queue_url, attribute_names: ['QueueArn'])
         expect(sns_client).to receive(:subscribe).and_raise(Aws::SNS::Errors::AuthorizationError.new(self, 'not found'))
-        allow(controller).to receive(:fetch_sns_topic_arns).and_return([])
         post :create , params: { sns_subscription: attributes }
         expect(response).to render_template(:new)
         expect(assigns(:sns_subscription).errors[:topic_arn]).to eq(['is not authorized'])

--- a/spec/factories/sns_subscription.rb
+++ b/spec/factories/sns_subscription.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :sns_subscription, class: Barbeque::SnsSubscription do
-    sequence(:topic_arn) { |n| "arn:aws:sns:ap-northest-1:123456789012/Topic-#{n}" }
+    sequence(:topic_arn) { |n| "arn:aws:sns:ap-northest-1:123456789012:Topic-#{n}" }
     job_queue
     job_definition
   end


### PR DESCRIPTION
Amazon SNS supports cross-region subscriptions: https://docs.aws.amazon.com/sns/latest/dg/sns-cross-region-delivery.html This patch added multi-region support to the SNS client, allowing cross-region subscriptions to be created from the Barbeque web console.

At the same time, this patch introduced a plain text input box for SNS topic ARNs rather than a select box, because:

1. A list of topic ARNs in multiple regions will be long, and
2. The list of topic ARNs in the default region is already long in Cookpad.

Screenshots:

| Before | After |
| -- | -- |
| <img width="848" height="459" alt="screenshot" src="https://github.com/user-attachments/assets/c15b6072-866d-4551-9055-19793a24ac04" /> | <img width="849" height="458" alt="screenshot" src="https://github.com/user-attachments/assets/d858f101-1f43-47c6-b6f8-03a8472ce2c2" /> |
