### PR TITLE
Wrap job description text in UI

### DIFF
--- a/app/assets/stylesheets/barbeque/job_definitions.css
+++ b/app/assets/stylesheets/barbeque/job_definitions.css
@@ -38,22 +38,8 @@
   display: block;
 }
 
-.barbeque_job_definitions_controller .table.table-bordered td {
-  word-wrap: break-word;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  white-space: normal;
-  min-width: 100px;
-}
-
+.barbeque_job_definitions_controller .table.table-bordered td,
 .barbeque_job_definitions_controller .table.table-bordered th {
-  word-wrap: break-word;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  white-space: normal;
+  overflow-wrap: anywhere;
   min-width: 100px;
-}
-
-.barbeque_job_definitions_controller .box-body {
-  overflow-x: scroll;
 }

--- a/app/assets/stylesheets/barbeque/job_definitions.css
+++ b/app/assets/stylesheets/barbeque/job_definitions.css
@@ -37,3 +37,23 @@
 .barbeque_job_definitions_controller .retry_configuration_field.active {
   display: block;
 }
+
+.barbeque_job_definitions_controller .table.table-bordered td {
+  word-wrap: break-word;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
+  min-width: 100px;
+}
+
+.barbeque_job_definitions_controller .table.table-bordered th {
+  word-wrap: break-word;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
+  min-width: 100px;
+}
+
+.barbeque_job_definitions_controller .box-body {
+  overflow-x: scroll;
+}


### PR DESCRIPTION
### Description

When there are longer strings (like URLs) on the job definitions show and index views in the "description" cell, the text can overflow the cell, making it hard to read and get from the index page to the details page. This PR adds some CSS to help improve the UX in this case.

@cookpad/platform-task-force 

### Screenshots

The "show" view, before:
<img height="400" alt="Screenshot 2025-12-09 at 10 23 06" src="https://github.com/user-attachments/assets/e17c313c-3d65-4984-bfc6-b622cff4dcdd" />

The "show" view, after:
<img height="400" alt="Screenshot 2025-12-09 at 10 23 28" src="https://github.com/user-attachments/assets/19b10cbf-2afb-40df-a37e-c27519974107" />

The "index" view, before:
<img height="400" alt="Screenshot 2025-12-09 at 10 22 55" src="https://github.com/user-attachments/assets/8a1ca17b-6667-4d50-bda4-59158bb63fbd" />

The "index" view, after:
<img height="400" alt="Screenshot 2025-12-09 at 10 23 41" src="https://github.com/user-attachments/assets/9228c603-bbcd-4079-a70a-de3adcb6dd9b" />